### PR TITLE
chore: Add support for React 18

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry=https://registry.npmjs.org
+registry=https://registry.yarnpkg.com

--- a/package.json
+++ b/package.json
@@ -71,12 +71,11 @@
     "@storybook/storybook-deployer": "^2.8.11",
     "@testing-library/dom": "^7.29.4",
     "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^12.1.5",
-    "@testing-library/react-hooks": "^7.0.1",
-    "@testing-library/user-event": "^12.6.3",
+    "@testing-library/react": "^13.0.0",
+    "@testing-library/user-event": "^13.0.0",
     "@types/classnames": "^2.2.11",
-    "@types/react": "^16.7",
-    "@types/react-dom": "^16.7",
+    "@types/react": "^18.0",
+    "@types/react-dom": "^18.0",
     "@types/testing-library__jest-dom": "^5.9.5",
     "@typescript-eslint/eslint-plugin": "^4.4.0",
     "@typescript-eslint/parser": "^4.10.0",
@@ -97,9 +96,9 @@
     "jest-pnp-resolver": "^1.0.1",
     "lint-staged": "^10.5.3",
     "node-require-context": "^1.0.0",
-    "react": "^16.0.0",
+    "react": "^18.0.0",
     "react-docgen-typescript-loader": "^3.7.2",
-    "react-dom": "^16.0.0",
+    "react-dom": "^18.0.0",
     "storybook-addon-jsx": "^7.3.14",
     "style-loader": "^2.0.0",
     "svgson": "^4.0.0",
@@ -109,6 +108,6 @@
   },
   "resolutions": {
     "@ebay/skin": "^13.0.0",
-    "@types/react": "^16.14.2"
+    "react-test-renderer": "^18.2.0"
   }
 }

--- a/src/common/component-utils/forwardRef.tsx
+++ b/src/common/component-utils/forwardRef.tsx
@@ -1,14 +1,15 @@
 import React, { FC, forwardRef } from 'react'
 
-const getDisplayName = Component => Component.displayName || Component.name || 'Component'
+const getDisplayName = <Props, >(Component: FC<Props>) => Component.displayName || Component.name || 'Component'
 
-// todo: type it, no idea how yet
+// Typescript will automatically find the return type crom forwardRef() function
+// Disabling eslint for this use case
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const withForwardRef = <Props, >(Component: FC<Props>) => {
     const ForwardRef = forwardRef<FC<Props>, Props>((props, ref) =>
         <Component {...props} forwardedRef={ref} />)
 
-    ForwardRef.displayName = getDisplayName(Component)
+    ForwardRef.displayName = getDisplayName<Props>(Component)
 
     return ForwardRef
 }

--- a/src/common/event-utils/__tests__/use-key-press.spec.tsx
+++ b/src/common/event-utils/__tests__/use-key-press.spec.tsx
@@ -1,6 +1,4 @@
-import React from 'react'
-import { act, renderHook } from '@testing-library/react-hooks'
-import { fireEvent } from '@testing-library/react'
+import { act, renderHook, fireEvent } from '@testing-library/react'
 import useKeyPress from '../use-key-press'
 
 

--- a/src/common/event-utils/__tests__/use-roving-index.spec.tsx
+++ b/src/common/event-utils/__tests__/use-roving-index.spec.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react'
-import { act, renderHook } from '@testing-library/react-hooks'
-import { fireEvent } from '@testing-library/react'
+import { act, renderHook, fireEvent } from '@testing-library/react'
 import useRovingIndex from '../use-roving-index'
 
 const TestComponent: FC = () => <div />

--- a/src/common/notice-utils/notice-content.tsx
+++ b/src/common/notice-utils/notice-content.tsx
@@ -1,9 +1,10 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import cx from 'classnames'
 
 type Props = {
     type: 'inline' | 'section' | 'page';
     className?: string;
+    children?: ReactNode;
 }
 
 const NoticeContent: FC<Props> = ({ className, type, children }) => {

--- a/src/common/tooltip-utils/tooltip-content.tsx
+++ b/src/common/tooltip-utils/tooltip-content.tsx
@@ -1,4 +1,4 @@
-import React, { FC, CSSProperties } from 'react'
+import React, { FC, CSSProperties, ReactNode } from 'react'
 import { EbayIcon } from '../../ebay-icon'
 import { findComponent } from '../component-utils'
 import { PointerDirection, TooltipType } from './types'
@@ -13,6 +13,7 @@ type TooltipContentProps = {
     showCloseButton?: boolean;
     a11yCloseText?: string;
     onClose?: () => void;
+    children?: ReactNode;
 }
 
 const TooltipContent: FC<TooltipContentProps> = ({

--- a/src/ebay-dialog-base/__tests__/index.spec.tsx
+++ b/src/ebay-dialog-base/__tests__/index.spec.tsx
@@ -5,6 +5,8 @@ import DialogBase from '../components/dialogBase';
 import EbayDialogHeader from '../components/dialog-header';
 import { HeaderFooterDialog } from './mocks';
 
+jest.useFakeTimers()
+
 describe('DialogBase', () => {
     it('should use id from header', () => {
         const wrapper = render(
@@ -63,6 +65,7 @@ describe('DialogBase', () => {
                 expect(spyCloseBtnClick).toHaveBeenCalled();
             });
             it('when background clicked then it should trigger onBackgroundClick event', () => {
+                jest.runAllTimers()
                 document.body.click();
                 expect(spyBackgroundClick).toHaveBeenCalled();
             });

--- a/src/ebay-dialog-base/components/dialog-close-button.tsx
+++ b/src/ebay-dialog-base/components/dialog-close-button.tsx
@@ -1,5 +1,9 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 
-const EbayDialogCloseButton: FC = ({ children }) => <>{children}</>
+type EbayDialogFooterProps = {
+    children?: ReactNode;
+}
+
+const EbayDialogCloseButton: FC = ({ children }: EbayDialogFooterProps) => <>{children}</>
 
 export default EbayDialogCloseButton

--- a/src/ebay-dialog-base/components/dialog-footer.tsx
+++ b/src/ebay-dialog-base/components/dialog-footer.tsx
@@ -1,5 +1,9 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 
-const EbayDialogFooter:FC = ({ children }) => <>{children}</>
+type EbayDialogFooterProps = {
+    children?: ReactNode;
+}
+
+const EbayDialogFooter:FC<EbayDialogFooterProps> = ({ children }) => <>{children}</>
 
 export default EbayDialogFooter

--- a/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/src/ebay-dialog-base/components/dialogBase.tsx
@@ -7,7 +7,8 @@ import React, {
     useState,
     ReactElement,
     cloneElement,
-    MouseEventHandler
+    MouseEventHandler,
+    ReactNode
 } from 'react'
 import classNames from 'classnames'
 import * as screenreaderTrap from 'makeup-screenreader-trap'
@@ -42,7 +43,8 @@ export interface DialogBaseProps<T> extends HTMLProps<T> {
     closeButton?: ReactElement;
     focus?: RefObject<HTMLAnchorElement & HTMLButtonElement>;
     animated?: boolean;
-    transitionElement?: TransitionElement
+    transitionElement?: TransitionElement;
+    children?: ReactNode;
 }
 
 export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({

--- a/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/src/ebay-dialog-base/components/dialogBase.tsx
@@ -83,12 +83,18 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
 
     useEffect(() => {
         const handleBackgroundClick = (e: React.MouseEvent) => {
-            if (drawerBaseEl && !drawerBaseEl.current.contains(e.target)) {
+            if (drawerBaseEl.current && !drawerBaseEl.current.contains(e.target)) {
                 onBackgroundClick(e)
             }
         }
         if (open) {
-            document.addEventListener('click', handleBackgroundClick as any, false)
+            // On React 18 useEffect hooks runs synchronous instead of asynchronous as React 17 or prior
+            // causing the event listener to be attached to the document at the same time that the dialog
+            // opens. Adding a timeout so the event is attached after the click event that opened the modal
+            // is finished.
+            setTimeout(() => {
+                document.addEventListener('click', handleBackgroundClick as any, false)
+            })
         }
         return () => document.removeEventListener('click', handleBackgroundClick as any, false)
     }, [onBackgroundClick, open])

--- a/src/ebay-field/field.tsx
+++ b/src/ebay-field/field.tsx
@@ -1,10 +1,11 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import classNames from 'classnames'
 import { FieldLayoutType } from './types'
 
 type FieldProps = {
     className?: string;
     layout?: FieldLayoutType;
+    children?: ReactNode;
 };
 
 const Field: FC<FieldProps> = ({

--- a/src/ebay-floating-label/hooks.tsx
+++ b/src/ebay-floating-label/hooks.tsx
@@ -18,7 +18,7 @@ type FloatingLabelHookReturn = {
     label: ReactNode;
     onBlur: () => void;
     onFocus: () => void;
-    Container: FC;
+    Container: FC<{ children?: ReactNode }>;
     ref: InputRef;
     placeholder: string;
 }
@@ -124,7 +124,7 @@ export function useFloatingLabel({
     })
 
     const FragmentContainer = useCallback(({ children }) => <>{children}</>, [])
-    const FloatingLabelContainer = useCallback(
+    const FloatingLabelContainer: FC<{ children?: ReactNode }> = useCallback(
         ({ children }) => <span className={floatingLabelClassName}>{children}</span>,
         [floatingLabelClassName]
     )

--- a/src/ebay-icon-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-icon-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -47,7 +47,6 @@ exports[`Storyshots ebay-icon-button Transparent 1`] = `
 exports[`Storyshots ebay-icon-button With Badges 1`] = `
 <p>
   <button
-    badgearialabel="new feature available"
     class="icon-btn icon-btn--badged"
     type="button"
   >
@@ -65,6 +64,7 @@ exports[`Storyshots ebay-icon-button With Badges 1`] = `
     </svg>
     <span
       aria-hidden="true"
+      aria-label="new feature available"
       class="badge"
     >
       1

--- a/src/ebay-icon-button/icon-button.tsx
+++ b/src/ebay-icon-button/icon-button.tsx
@@ -19,6 +19,7 @@ const EbayIconButton:FC<Props> = ({
     href,
     icon,
     badgeNumber,
+    badgeAriaLabel,
     transparent,
     className: extraClasses,
     ...rest
@@ -35,7 +36,7 @@ const EbayIconButton:FC<Props> = ({
     const children = (
         <>
             <EbayIcon name={icon} />
-            {badgeNumber && <EbayBadge type="icon" number={badgeNumber} />}
+            {badgeNumber && <EbayBadge type="icon" number={badgeNumber} aria-label={badgeAriaLabel} />}
         </>
     )
 

--- a/src/ebay-infotip/ebay-infotip-content.tsx
+++ b/src/ebay-infotip/ebay-infotip-content.tsx
@@ -2,8 +2,12 @@
  * This Component is used only for finding it as a child of EbayInfotip
  * and pass the properties to TooltipContent
 */
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 
-const EbayInfotipContent: FC = ({ children }) => <>{children}</>
+type EbayInfotipContentProps = {
+    children?: ReactNode;
+}
+
+const EbayInfotipContent: FC = ({ children }: EbayInfotipContentProps) => <>{children}</>
 
 export default EbayInfotipContent

--- a/src/ebay-infotip/ebay-infotip-host.tsx
+++ b/src/ebay-infotip/ebay-infotip-host.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, FC, RefObject } from 'react'
+import React, { ComponentProps, FC, RefObject, ReactNode } from 'react'
 import classNames from 'classnames/dedupe'
 import { EbayIcon, Icon } from '../ebay-icon'
 import { withForwardRef } from '../common/component-utils/forwardRef'
@@ -8,6 +8,7 @@ type InfotipHostProps = ComponentProps<'button'> & {
     icon?: Icon;
     forwardedRef?: RefObject<HTMLAnchorElement & HTMLButtonElement>;
     variant?: Variant;
+    children?: ({ icon }) => ReactNode | ReactNode
 }
 
 const EbayInfotipHost: FC<InfotipHostProps> = ({

--- a/src/ebay-infotip/ebay-infotip.tsx
+++ b/src/ebay-infotip/ebay-infotip.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, createElement, CSSProperties, FC, useRef } from 'react'
+import React, { cloneElement, createElement, CSSProperties, FC, useRef, ReactNode } from 'react'
 import classNames from 'classnames'
 import { findComponent } from '../common/component-utils'
 import { Tooltip, TooltipHost, TooltipContent, PointerDirection, useTooltip } from '../common/tooltip-utils'
@@ -21,6 +21,7 @@ type InfotipProps = {
     a11yCloseText: string;
     'aria-label'?: string;
     className?: string;
+    children?: ReactNode;
 };
 
 const EbayInfotip: FC<InfotipProps> = ({

--- a/src/ebay-inline-notice/inline-notice.tsx
+++ b/src/ebay-inline-notice/inline-notice.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect } from 'react'
+import React, { FC, useEffect, ReactNode } from 'react'
 import classNames from 'classnames'
 import { EbayNoticeContent } from '../ebay-notice-base/components/ebay-notice-content'
 import NoticeContent from '../common/notice-utils/notice-content'
@@ -12,6 +12,7 @@ type Props = {
     'aria-label': string;
     hidden?: boolean;
     className?: string
+    children?: ReactNode;
 }
 
 const EbayInlineNotice: FC<Props> = ({

--- a/src/ebay-notice-base/components/ebay-notice-title/notice-title.tsx
+++ b/src/ebay-notice-base/components/ebay-notice-title/notice-title.tsx
@@ -1,6 +1,10 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 
-const EbayNoticeTitle: FC = ({ children }) => (
+type EbayNoticeTitleProps = {
+    children?: ReactNode;
+}
+
+const EbayNoticeTitle: FC = ({ children }: EbayNoticeTitleProps) => (
     <span className="page-notice__title">
         {children}
     </span>

--- a/src/ebay-page-notice/page-notice-footer.tsx
+++ b/src/ebay-page-notice/page-notice-footer.tsx
@@ -1,8 +1,9 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import NoticeFooter from '../common/notice-utils/notice-footer'
 
 type Props = {
     className?: string;
+    children?: ReactNode;
 }
 
 const EbayPageNoticeFooter: FC<Props> = ({ className, children }) => (

--- a/src/ebay-progress-stepper/ebay-progress-step.tsx
+++ b/src/ebay-progress-stepper/ebay-progress-step.tsx
@@ -1,4 +1,4 @@
-import React, { Children, FC, ReactElement } from 'react'
+import React, { Children, FC, ReactElement, ReactNode } from 'react'
 import classNames from 'classnames'
 import { EbayIcon, Icon } from '../ebay-icon'
 import { StepState, StepType } from './types'
@@ -10,6 +10,7 @@ export type EbayProgressStepProps = {
     current?: boolean;
     number?: number;
     className?: string;
+    children?: ReactNode;
 }
 
 const typeClasses: { [key in StepType]: string } = {

--- a/src/ebay-progress-stepper/ebay-progress-stepper.tsx
+++ b/src/ebay-progress-stepper/ebay-progress-stepper.tsx
@@ -1,4 +1,4 @@
-import React, { Children, cloneElement, FC, Fragment, ReactElement } from 'react'
+import React, { Children, cloneElement, FC, Fragment, ReactElement, ReactNode } from 'react'
 import classNames from 'classnames'
 import { StepperDirection, StepState, StepType } from './types'
 import { EbayProgressStepProps } from './ebay-progress-step'
@@ -7,6 +7,7 @@ type ProgressStepperProps = {
     direction?: StepperDirection;
     defaultState?: StepState;
     className?: string;
+    children?: ReactNode;
 }
 
 const EbayProgressStepper: FC<ProgressStepperProps> = ({

--- a/src/ebay-progress-stepper/ebay-progress-title.tsx
+++ b/src/ebay-progress-stepper/ebay-progress-title.tsx
@@ -1,7 +1,8 @@
-import { createElement, FC } from 'react'
+import { createElement, FC, ReactNode } from 'react'
 
 type Props = {
     as?: string;
+    children?: ReactNode;
 }
 
 const EbayProgressTitle: FC<Props> = ({

--- a/src/ebay-section-notice/section-notice-footer.tsx
+++ b/src/ebay-section-notice/section-notice-footer.tsx
@@ -1,8 +1,9 @@
-import React, { FC } from 'react'
+import React, { FC, ReactNode } from 'react'
 import NoticeFooter from '../common/notice-utils/notice-footer'
 
 type Props = {
     className?: string;
+    children?: ReactNode;
 }
 
 const EbaySectionNoticeFooter: FC<Props> = ({ className, children }) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,9 +2507,9 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
-"@testing-library/dom@^8.0.0":
+"@testing-library/dom@^8.5.0":
   version "8.14.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.14.0.tgz#c9830a21006d87b9ef6e1aae306cf49b0283e28e"
+  resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-8.14.0.tgz#c9830a21006d87b9ef6e1aae306cf49b0283e28e"
   integrity sha512-m8FOdUo77iMTwVRCyzWcqxlEIk+GnopbrRI15a0EaLbpZSCinIVI4kSQzWhkShK83GogvEFJSsHF3Ws0z1vrqA==
   dependencies:
     "@babel/code-frame" "^7.10.4"
@@ -2536,30 +2536,19 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react-hooks@^7.0.1":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz#3388d07f562d91e7f2431a4a21b5186062ecfee0"
-  integrity sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==
+"@testing-library/react@^13.0.0":
+  version "13.3.0"
+  resolved "https://registry.npmjs.org/@testing-library/react/-/react-13.3.0.tgz#bf298bfbc5589326bbcc8052b211f3bb097a97c5"
+  integrity sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@types/react" ">=16.9.0"
-    "@types/react-dom" ">=16.9.0"
-    "@types/react-test-renderer" ">=16.9.0"
-    react-error-boundary "^3.1.0"
+    "@testing-library/dom" "^8.5.0"
+    "@types/react-dom" "^18.0.0"
 
-"@testing-library/react@^12.1.5":
-  version "12.1.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
-  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^8.0.0"
-    "@types/react-dom" "<18.0.0"
-
-"@testing-library/user-event@^12.6.3":
-  version "12.8.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.8.3.tgz#1aa3ed4b9f79340a1e1836bc7f57c501e838704a"
-  integrity sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==
+"@testing-library/user-event@^13.0.0":
+  version "13.5.0"
+  resolved "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
+  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -2796,26 +2785,12 @@
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
   integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
-"@types/react-dom@<18.0.0":
-  version "17.0.17"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.17.tgz#2e3743277a793a96a99f1bf87614598289da68a1"
-  integrity sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==
-  dependencies:
-    "@types/react" "^17"
-
-"@types/react-dom@>=16.9.0":
+"@types/react-dom@^18.0", "@types/react-dom@^18.0.0":
   version "18.0.5"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.5.tgz#330b2d472c22f796e5531446939eacef8378444a"
+  resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.5.tgz#330b2d472c22f796e5531446939eacef8378444a"
   integrity sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==
   dependencies:
     "@types/react" "*"
-
-"@types/react-dom@^16.7":
-  version "16.9.16"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.16.tgz#c591f2ed1c6f32e9759dfa6eb4abfd8041f29e39"
-  integrity sha512-Oqc0RY4fggGA3ltEgyPLc3IV9T73IGoWjkONbsyJ3ZBn+UPPCYpU2ec0i3cEbJuEdZtkqcCF2l1zf2pBdgUGSg==
-  dependencies:
-    "@types/react" "^16"
 
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
@@ -2824,17 +2799,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-test-renderer@>=16.9.0":
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz#7b7f69ca98821ea5501b21ba24ea7b6139da2243"
-  integrity sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react@*", "@types/react@>=16.9.0", "@types/react@^16", "@types/react@^16.14.2", "@types/react@^16.7", "@types/react@^17":
+"@types/react@*":
   version "16.14.28"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.28.tgz#073258f3fe7bb80c748842c1f93aeaafe16dffad"
   integrity sha512-83zBE6+XUVXsdL3iFzOyUewdauaU+KviKCHEGOgSW52coAuqW7tEKQM0E9+ZC0Zk6TELQ2/JgogPvp7FavzFwg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^18.0":
+  version "18.0.14"
+  resolved "https://registry.npmjs.org/@types/react/-/react-18.0.14.tgz#e016616ffff51dba01b04945610fe3671fdbe06d"
+  integrity sha512-x4gGuASSiWmo0xjDLpm5mPb52syZHJx02VKbqUKdLmKtAwIh63XClGsiTI1K6DO5q7ox4xAsQrU+Gl3+gGXF9Q==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -10635,15 +10612,13 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-react-dom@^16.0.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
+react-dom@^18.0.0:
+  version "18.2.0"
+  resolved "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
+  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.23.0"
 
 react-element-to-jsx-string@^14.3.1, react-element-to-jsx-string@^14.3.4:
   version "14.3.4"
@@ -10653,13 +10628,6 @@ react-element-to-jsx-string@^14.3.1, react-element-to-jsx-string@^14.3.4:
     "@base2/pretty-print-object" "1.0.1"
     is-plain-object "5.0.0"
     react-is "17.0.2"
-
-react-error-boundary@^3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
-  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
 
 react-focus-lock@^2.9.1:
   version "2.9.1"
@@ -10689,14 +10657,14 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
-react-is@17.0.2, react-is@^17.0.1, react-is@^17.0.2:
+react-is@17.0.2, react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0:
+"react-is@^16.12.0 || ^17.0.0 || ^18.0.0", react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react-is@^16.13.1, react-is@^16.8.4:
@@ -10747,9 +10715,9 @@ react-select@^3.2.0:
     react-input-autosize "^3.0.0"
     react-transition-group "^4.3.0"
 
-react-shallow-renderer@^16.13.1:
+react-shallow-renderer@^16.15.0:
   version "16.15.0"
-  resolved "https://registry.yarnpkg.com/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
+  resolved "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz#48fb2cf9b23d23cde96708fe5273a7d3446f4457"
   integrity sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==
   dependencies:
     object-assign "^4.1.1"
@@ -10785,15 +10753,14 @@ react-syntax-highlighter@^15.4.5:
     prismjs "^1.27.0"
     refractor "^3.6.0"
 
-"react-test-renderer@^16.8.0 || ^17.0.0":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-17.0.2.tgz#4cd4ae5ef1ad5670fc0ef776e8cc7e1231d9866c"
-  integrity sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==
+"react-test-renderer@^16.8.0 || ^17.0.0", react-test-renderer@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz#1dd912bd908ff26da5b9fca4fd1c489b9523d37e"
+  integrity sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==
   dependencies:
-    object-assign "^4.1.1"
-    react-is "^17.0.2"
-    react-shallow-renderer "^16.13.1"
-    scheduler "^0.20.2"
+    react-is "^18.2.0"
+    react-shallow-renderer "^16.15.0"
+    scheduler "^0.23.0"
 
 react-transition-group@^4.3.0:
   version "4.4.2"
@@ -10805,14 +10772,12 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react@^16.0.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
+react@^18.0.0:
+  version "18.2.0"
+  resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -11365,21 +11330,12 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.23.0:
+  version "0.23.0"
+  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz#ba8041afc3d30eb206a487b6b384002e4e61fdfe"
+  integrity sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==
   dependencies:
     loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.20.2:
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
-  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 schema-utils@2.7.0:
   version "2.7.0"


### PR DESCRIPTION
Note: this should NOT be a breaking change since it should also support react 16;

- Upgrade devDependencies to React 18
- Resolve react-test-render to 18 in order to fix snapshot testing ([issue](https://github.com/storybookjs/storybook/issues/17985#issuecomment-1116711479))
- Fix dialog document click event for React 18 (useEffect are sync on React causing issue on document event handlers)
- Fix props checking
- Remove testing-library/react-hook and upgrade testing-library/react to 13 (with renderHooks)
- Fix React 18 types (missing `children` on components)