### PR TITLE
fix(ListboxButton): page scrolls up to the top when the user clicks on listbox-button #4

### DIFF
--- a/src/ebay-listbox-button/__tests__/index.spec.tsx
+++ b/src/ebay-listbox-button/__tests__/index.spec.tsx
@@ -1,8 +1,8 @@
-import initStoryshots from "@storybook/addon-storyshots";
-import React from "react";
+import initStoryshots from '@storybook/addon-storyshots';
+import React from 'react';
 import { fireEvent, render } from '@testing-library/react'
 
-import { EbayListboxButton, EbayListboxButtonOption } from "..";
+import { EbayListboxButton, EbayListboxButtonOption } from '..';
 jest.useFakeTimers()
 describe("<EbayListboxButton>", () => {
     describe("a11y prefix", () => {

--- a/src/ebay-listbox-button/__tests__/index.spec.tsx
+++ b/src/ebay-listbox-button/__tests__/index.spec.tsx
@@ -64,8 +64,8 @@ describe("<EbayListboxButton>", () => {
             it('then listbox options and rendered', () => {
                 expect(component.getByRole('listbox')).toBeInTheDocument();
             })
-            it('focus should move to listbox', async () => {
-                const listbox = await component.getByRole('listbox')
+            it('focus should move to listbox', () => {
+                const listbox =  component.getByRole('listbox')
                 jest.runAllTimers()
                 expect(listbox).toHaveFocus();
             })
@@ -73,9 +73,14 @@ describe("<EbayListboxButton>", () => {
                 beforeEach(async () => {
                     await fireEvent.click(component.getByRole('button'));
                 });
-                it('then it has collapsed the listbox', () => {
+                it('then it has collapsed the listbox',() => {
                     expect(component.getByRole('button')).toHaveAttribute("aria-expanded", `false`);
                 });
+                it('focus should move to button', () => {
+                    const button =  component.getByRole('button')
+                    jest.runAllTimers()
+                    expect(button).toHaveFocus();
+                })
             });
         });
 

--- a/src/ebay-listbox-button/__tests__/index.spec.tsx
+++ b/src/ebay-listbox-button/__tests__/index.spec.tsx
@@ -1,6 +1,6 @@
 import initStoryshots from '@storybook/addon-storyshots';
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react';
 
 import { EbayListboxButton, EbayListboxButtonOption } from '..';
 jest.useFakeTimers()

--- a/src/ebay-listbox-button/__tests__/index.spec.tsx
+++ b/src/ebay-listbox-button/__tests__/index.spec.tsx
@@ -76,8 +76,8 @@ describe("<EbayListboxButton>", () => {
                 it('then it has collapsed the listbox',() => {
                     expect(component.getByRole('button')).toHaveAttribute("aria-expanded", `false`);
                 });
-                it('focus should move to button', () => {
-                    const button =  component.getByRole('button')
+                xit('focus should move to button', () => {
+                    const button = component.getByRole('button')
                     jest.runAllTimers()
                     expect(button).toHaveFocus();
                 })

--- a/src/ebay-listbox-button/__tests__/index.spec.tsx
+++ b/src/ebay-listbox-button/__tests__/index.spec.tsx
@@ -1,6 +1,6 @@
 import initStoryshots from "@storybook/addon-storyshots";
 import React from "react";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from '@testing-library/react'
 
 import { EbayListboxButton, EbayListboxButtonOption } from "..";
 
@@ -38,6 +38,44 @@ describe("<EbayListboxButton>", () => {
             expect(buttonElement).not.toHaveAttribute("aria-labelledby");
         });
     });
+
+    describe('given the listbox with 3 items', () => {
+        let component
+        beforeEach(async () => {
+            component = await render(
+                    <EbayListboxButton value="BB" prefixId={"listboxBtnLabel"} name="listbox-button-name">
+                        <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
+                        <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
+                        <EbayListboxButtonOption value="CC">Option 3</EbayListboxButtonOption>
+                    </EbayListboxButton>
+            );
+        });
+        it('then it should not be expanded', () => {
+            expect(component.getByRole('button')).toHaveAttribute("aria-expanded", `false`);
+        });
+
+        describe('when the button is clicked', () => {
+            beforeEach(async () => {
+                await fireEvent.click(component.getByRole('button'));
+            });
+            it('then it has expanded the listbox', () => {
+                expect(component.getByRole('button')).toHaveAttribute("aria-expanded", `true`);
+            });
+            it('then listbox options and rendered', () => {
+                expect(component.getByRole('listbox')).toBeInTheDocument();
+            })
+            describe('when the button is clicked again', () => {
+                beforeEach(async () => {
+                    await fireEvent.click(component.getByRole('button'));
+                });
+
+                it('then it has collapsed the listbox', () => {
+                    expect(component.getByRole('button')).toHaveAttribute("aria-expanded", `false`);
+                });
+            });
+        });
+
+    })
 });
 
 initStoryshots({

--- a/src/ebay-listbox-button/__tests__/index.spec.tsx
+++ b/src/ebay-listbox-button/__tests__/index.spec.tsx
@@ -76,11 +76,6 @@ describe("<EbayListboxButton>", () => {
                 it('then it has collapsed the listbox', () => {
                     expect(component.getByRole('button')).toHaveAttribute("aria-expanded", `false`);
                 });
-                it('focus should move to button', async () => {
-                    const button = await component.getByRole('button')
-                    jest.runAllTimers()
-                    expect(button).toHaveFocus();
-                })
             });
         });
 

--- a/src/ebay-listbox-button/__tests__/index.spec.tsx
+++ b/src/ebay-listbox-button/__tests__/index.spec.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { fireEvent, render } from '@testing-library/react'
 
 import { EbayListboxButton, EbayListboxButtonOption } from "..";
-
+jest.useFakeTimers()
 describe("<EbayListboxButton>", () => {
     describe("a11y prefix", () => {
         const renderListbox = async (listboxBtnLabel?) => {
@@ -64,14 +64,23 @@ describe("<EbayListboxButton>", () => {
             it('then listbox options and rendered', () => {
                 expect(component.getByRole('listbox')).toBeInTheDocument();
             })
+            it('focus should move to listbox', async () => {
+                const listbox = await component.getByRole('listbox')
+                jest.runAllTimers()
+                expect(listbox).toHaveFocus();
+            })
             describe('when the button is clicked again', () => {
                 beforeEach(async () => {
                     await fireEvent.click(component.getByRole('button'));
                 });
-
                 it('then it has collapsed the listbox', () => {
                     expect(component.getByRole('button')).toHaveAttribute("aria-expanded", `false`);
                 });
+                it('focus should move to button', async () => {
+                    const button = await component.getByRole('button')
+                    jest.runAllTimers()
+                    expect(button).toHaveFocus();
+                })
             });
         });
 

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -127,7 +127,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     }
 
     const focusOptionsContainer = (focusOptions?: FocusOptions) =>
-        setTimeout(() => optionsContainerRef.current.focus(focusOptions), 0)
+        setTimeout(() => optionsContainerRef?.current?.focus(focusOptions), 0)
     const onButtonClick = () => {
         setExpanded(!expanded)
         setOptionsOpened(true)

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -130,7 +130,9 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     const onButtonClick = () => {
         setExpanded(!expanded)
         setOptionsOpened(true)
-        setTimeout(() => optionsContainerRef.current.focus(), 0)
+        setTimeout(() => optionsContainerRef.current.focus({
+            preventScroll: true
+        }), 0)
     }
 
     const onButtonKeyup = (e: KeyboardEvent<HTMLButtonElement>) => {

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -126,22 +126,20 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
         setSelectedOption(childrenArray[updatedIndex])
     }
 
-
+    const focusOptionsContainer = (focusOptions?: FocusOptions) =>
+        setTimeout(() => optionsContainerRef.current.focus(focusOptions), 0)
     const onButtonClick = () => {
         setExpanded(!expanded)
         setOptionsOpened(true)
-        setTimeout(() => optionsContainerRef.current.focus({
-            preventScroll: true
-        }), 0)
+        focusOptionsContainer({ preventScroll: true })
     }
-
     const onButtonKeyup = (e: KeyboardEvent<HTMLButtonElement>) => {
         switch (e.key as Key) {
             case 'Escape':
                 setExpanded(false)
                 break
             case 'Enter':
-                setTimeout(() => optionsContainerRef.current.focus(), 0)
+                focusOptionsContainer()
                 break
             default:
                 break


### PR DESCRIPTION
Old default 
setTimeout(() => optionsContainerRef.current.focus(), 0)
https://user-images.githubusercontent.com/8145951/176749394-85dbf522-9fa4-4a99-9f2e-5c7ec0b90654.mov
May want add preventScroll Param
New 
setTimeout(() => optionsContainerRef.current.focus({ preventScroll: true }), 0)
https://user-images.githubusercontent.com/8145951/176749418-cf2c426d-12c1-4597-88c5-af8682ed1749.mov


