### PR TITLE
Skin 14 Upgrade

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,0 @@
-<!-- Force MarketSans for all body text -->
-<style>
-    html > body {
-        font-family: "Market Sans", Arial, sans-serif;
-    }
-</style>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -5,6 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import { EbaySvg } from '../src'
 
 import "@ebay/skin"
+import "@ebay/skin/tokens"
 
 export const decorators = [
     withA11y,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ eBayUI React components
 
 * [Node.js](https://nodejs.org/en/) (v16.14+)
 * [React](https://reactjs.org/) (v16.8+)
-* [eBay Skin](https://ebay.github.io/skin/) (v13)
+* [eBay Skin](https://ebay.github.io/skin/) (v14)
 
 ### eBayUI Components
 * [x] [ebay-alert-dialog](src/ebay-alert-dialog)

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ yarn update-icons
 ### Requirements for new component
 
 If you implement a new component, make sure that it complies with eBay UI guidelines:
-  * [Skin](https://ebay.github.io/skin/ds6/)
+  * [Skin](https://ebay.github.io/skin/)
   * [MIND pattern](https://ebay.gitbook.io/mindpatterns/) for accessibility
 
 One way to comply those guidelines is to implement your new component as similiar as possible with the Marko [eBayUI Core](https://github.com/eBay/ebayui-core), or port the Marko implementation to React. This means the new component should:

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "author": "tmanyanov@ebay.com",
   "license": "ISC",
   "peerDependencies": {
-    "@ebay/skin": "^13.0.0",
+    "@ebay/skin": "^14.0.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@babel/register": "^7.0.0",
-    "@ebay/skin": "^13.7.1",
+    "@ebay/skin": "^14",
     "@microsoft/eslint-formatter-sarif": "^3.0.0",
     "@storybook/addon-a11y": "^6.5.6",
     "@storybook/addon-essentials": "^6.5.6",
@@ -100,7 +100,6 @@
     "typescript": "^3.9.5"
   },
   "resolutions": {
-    "@ebay/skin": "^13.0.0",
     "react-test-renderer": "^18.2.0"
   }
 }

--- a/src/ebay-badge/README.md
+++ b/src/ebay-badge/README.md
@@ -20,7 +20,7 @@ import '@ebay/skin/badge'
 
 ## ...or using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/badge/ds6/badge.css'
+import '@ebay/skin/dist/badge/badge.css'
 ```
 
 ```jsx harmony

--- a/src/ebay-badge/README.md
+++ b/src/ebay-badge/README.md
@@ -20,7 +20,7 @@ import '@ebay/skin/badge'
 
 ## ...or using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/badge/badge.css'
+import '@ebay/skin/badge.css'
 ```
 
 ```jsx harmony

--- a/src/ebay-breadcrumbs/README.md
+++ b/src/ebay-breadcrumbs/README.md
@@ -16,12 +16,6 @@ import '@ebay/skin/breadcrumbs';
 import '@ebay/skin/utility';
 ```
 
-### or if using LESS
-```jsx
-import '@ebay/skin/src/less/breadcrumbs/ds6/breadcrumbs.less';
-import '@ebay/skin/src/less/utility/ds6/utility.less';
-```
-
 ### Breadcrumbs
 ```jsx
 <EbayBreadcrumbs a11yHeadingText="Page navigation">

--- a/src/ebay-button/README.md
+++ b/src/ebay-button/README.md
@@ -15,7 +15,7 @@ import "@ebay/skin/button"
 ```
 ### Or import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/button/ds6/button.css'
+import '@ebay/skin/dist/button/button.css'
 ```
 
 ### Big button

--- a/src/ebay-button/README.md
+++ b/src/ebay-button/README.md
@@ -15,7 +15,7 @@ import "@ebay/skin/button"
 ```
 ### Or import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/button/button.css'
+import '@ebay/skin/button.css'
 ```
 
 ### Big button

--- a/src/ebay-checkbox/README.md
+++ b/src/ebay-checkbox/README.md
@@ -19,7 +19,7 @@ import '@ebay/skin/checkbox'
 
 ## ...or using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/checkbox/checkbox.css'
+import '@ebay/skin/checkbox.css'
 ```
 
 ```jsx

--- a/src/ebay-checkbox/README.md
+++ b/src/ebay-checkbox/README.md
@@ -19,7 +19,7 @@ import '@ebay/skin/checkbox'
 
 ## ...or using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/checkbox/ds6/checkbox.css'
+import '@ebay/skin/dist/checkbox/checkbox.css'
 ```
 
 ```jsx

--- a/src/ebay-cta-button/README.md
+++ b/src/ebay-cta-button/README.md
@@ -17,7 +17,7 @@ import "@ebay/skin/cta-button"
 
 ### Or import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/cta-button/ds6/cta-button.css'
+import '@ebay/skin/dist/cta-button/cta-button.css'
 ```
 
 ### Big button

--- a/src/ebay-cta-button/README.md
+++ b/src/ebay-cta-button/README.md
@@ -17,7 +17,7 @@ import "@ebay/skin/cta-button"
 
 ### Or import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/cta-button/cta-button.css'
+import '@ebay/skin/cta-button.css'
 ```
 
 ### Big button

--- a/src/ebay-drawer-dialog/README.md
+++ b/src/ebay-drawer-dialog/README.md
@@ -12,7 +12,7 @@ import "@ebay/skin/drawer-dialog"
 ```
 ### Or import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/drawer-dialog/drawer-dialog.css'
+import '@ebay/skin/drawer-dialog.css'
 ```
 ### Simple opened dialog
 ```jsx

--- a/src/ebay-drawer-dialog/README.md
+++ b/src/ebay-drawer-dialog/README.md
@@ -12,7 +12,7 @@ import "@ebay/skin/drawer-dialog"
 ```
 ### Or import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/drawer-dialog/ds6/drawer-dialog.css'
+import '@ebay/skin/dist/drawer-dialog/drawer-dialog.css'
 ```
 ### Simple opened dialog
 ```jsx

--- a/src/ebay-expand-button/README.md
+++ b/src/ebay-expand-button/README.md
@@ -17,7 +17,7 @@ import "@ebay/skin/expand-button"
 
 ### Or import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/expand-button/expand-button.css'
+import '@ebay/skin/expand-button.css'
 
 ```
 

--- a/src/ebay-expand-button/README.md
+++ b/src/ebay-expand-button/README.md
@@ -17,7 +17,7 @@ import "@ebay/skin/expand-button"
 
 ### Or import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/expand-button/ds6/expand-button.css'
+import '@ebay/skin/dist/expand-button/expand-button.css'
 
 ```
 

--- a/src/ebay-field/README.md
+++ b/src/ebay-field/README.md
@@ -9,11 +9,11 @@ import { EbayField, EbayLabel, fieldLayoutType, EbayFieldDescription, fieldDescr
 ```
 ## Import following styles from SKIN
 ```jsx harmony
-import '@ebay/skin/src/less/field/ds6/field';
+import '@ebay/skin/field';
 ```
 ## Import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/field/ds6/field.css'
+import '@ebay/skin/dist/field/field.css'
 ```
 ## Usage
 ```

--- a/src/ebay-field/README.md
+++ b/src/ebay-field/README.md
@@ -13,7 +13,7 @@ import '@ebay/skin/field';
 ```
 ## Import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/field/field.css'
+import '@ebay/skin/field.css'
 ```
 ## Usage
 ```

--- a/src/ebay-floating-label/README.md
+++ b/src/ebay-floating-label/README.md
@@ -21,7 +21,7 @@ import "@ebay/skin/floating-label";
 ## or import styles using SCSS/CSS
 
 ```jsx harmony
-import "@ebay/skin/dist/floating-label/ds6/floating-label.css";
+import "@ebay/skin/dist/floating-label/floating-label.css";
 ```
 
 ## Usage

--- a/src/ebay-floating-label/README.md
+++ b/src/ebay-floating-label/README.md
@@ -21,7 +21,7 @@ import "@ebay/skin/floating-label";
 ## or import styles using SCSS/CSS
 
 ```jsx harmony
-import "@ebay/skin/dist/floating-label/floating-label.css";
+import "@ebay/skin/floating-label.css";
 ```
 
 ## Usage

--- a/src/ebay-icon-button/README.md
+++ b/src/ebay-icon-button/README.md
@@ -17,7 +17,7 @@ import "@ebay/skin/icon-button"
 
 ### Or import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/icon-button/ds6/icon-button.css'
+import '@ebay/skin/dist/icon-button/icon-button.css'
 ```
 
 ### Icon button

--- a/src/ebay-icon-button/README.md
+++ b/src/ebay-icon-button/README.md
@@ -17,7 +17,7 @@ import "@ebay/skin/icon-button"
 
 ### Or import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/icon-button/icon-button.css'
+import '@ebay/skin/icon-button.css'
 ```
 
 ### Icon button

--- a/src/ebay-infotip/README.md
+++ b/src/ebay-infotip/README.md
@@ -58,7 +58,7 @@ yarn add @ebay/ebayui-core-react
 | ----------------- | -------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `variant`         | String   | No       | No       | Either modal or default. If modal will show the mobile version of infotip                                                                                    |
 | `pointer`         | String   | No       | No       | options are `top-left`, `top`, `top-right`, `right`, `right-bottom`, `right-top`, `bottom-left`, `bottom-right`, `bottom`, `left`, `left-bottom`, `left-top` |
-| `icon`            | String   | No       | No       | Different icon to be used than `information-small`. Full list [here](https://ebay.github.io/skin/ds6/index.html#icon)                                        |
+| `icon`            | String   | No       | No       | Different icon to be used than `information-small`. Full list [here](https://ebay.github.io/skin/index.html#icon)                                        |
 | `disabled`        | Boolean  | No       | No       | Define if the infotip is disabled or not                                                                                                                     |
 | `overlayStyle`    | Object   | No       | No       | Style object to customize default values for the overlay. It can be used all CSS properties like `top`, `left`, `bottom`, `right`.                           |
 | `initialExpanded` | Boolean  | No       | No       | Open the tooltip on the initial render                                                                                                                       |

--- a/src/ebay-infotip/README.md
+++ b/src/ebay-infotip/README.md
@@ -24,8 +24,8 @@ import '@ebay/skin/icon-button'
 
 ### or if using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/infotip/ds6/infotip.css'
-import '@ebay/skin/dist/icon-button/ds6/icon-button.css'
+import '@ebay/skin/dist/infotip/infotip.css'
+import '@ebay/skin/dist/icon-button/icon-button.css'
 ```
 
 ## Usage

--- a/src/ebay-infotip/README.md
+++ b/src/ebay-infotip/README.md
@@ -24,8 +24,8 @@ import '@ebay/skin/icon-button'
 
 ### or if using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/infotip/infotip.css'
-import '@ebay/skin/dist/icon-button/icon-button.css'
+import '@ebay/skin/infotip.css'
+import '@ebay/skin/icon-button.css'
 ```
 
 ## Usage

--- a/src/ebay-inline-notice/README.md
+++ b/src/ebay-inline-notice/README.md
@@ -27,12 +27,6 @@ import { EbayInlineNotice, EbayNoticeContent } from '@ebay/ebayui-core-react/eba
 
 ### Import following styles from SKIN
 
-#### Less files
-
-```less
-@import "~@ebay/skin/src/less/inline-notice/ds6/inline-notice.less";
-```
-
 #### JavaScript files
 
 ```jsx harmony

--- a/src/ebay-legacy-floating-label/README.md
+++ b/src/ebay-legacy-floating-label/README.md
@@ -19,7 +19,7 @@ import "@ebay/skin/legacy-textbox";
 ## or import styles using SCSS/CSS
 
 ```jsx harmony
-import "@ebay/skin/dist/legacy-textbox/legacy-textbox.css";
+import "@ebay/skin/legacy-textbox.css";
 ```
 
 ## Usage

--- a/src/ebay-legacy-floating-label/README.md
+++ b/src/ebay-legacy-floating-label/README.md
@@ -19,7 +19,7 @@ import "@ebay/skin/legacy-textbox";
 ## or import styles using SCSS/CSS
 
 ```jsx harmony
-import "@ebay/skin/dist/legacy-textbox/ds6/legacy-textbox.css";
+import "@ebay/skin/dist/legacy-textbox/legacy-textbox.css";
 ```
 
 ## Usage

--- a/src/ebay-legacy-floating-label/__tests__/index.stories.tsx
+++ b/src/ebay-legacy-floating-label/__tests__/index.stories.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
 import { EbayButton, EbayLegacyFloatingLabel } from '../../index'
-import '@ebay/skin/dist/legacy-textbox/ds6/legacy-textbox.css'
+import '@ebay/skin/legacy-textbox'
 
 storiesOf(`ebay-legacy-floating-label`, module)
     .add(`Default floating label`, () => (

--- a/src/ebay-listbox-button/README.md
+++ b/src/ebay-listbox-button/README.md
@@ -9,7 +9,7 @@ import { EbayListboxButton, EbayListboxButtonOption } from '@ebay/ebayui-core-re
 ```
 ## Import following styles from SKIN
 ```jsx harmony
-import '@ebay/skin/src/less/listbox-button/ds6/listbox-button';
+import '@ebay/skin/listbox-button';
 ```
 ## Usage
 ```

--- a/src/ebay-page-notice/README.md
+++ b/src/ebay-page-notice/README.md
@@ -17,14 +17,6 @@ import {
 
 ### Import following styles from SKIN
 
-#### Less files
-
-```less
-@import "~@ebay/skin/src/less/page-notice/ds6/page-notice.less";
-```
-
-#### JavaScript files
-
 ```jsx harmony
 import "@ebay/skin/page-notice";
 ```

--- a/src/ebay-radio/README.md
+++ b/src/ebay-radio/README.md
@@ -22,7 +22,7 @@ import "@ebay/skin/radio"
 
 ### or SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/radio/ds6/radio.css'
+import '@ebay/skin/dist/radio/radio.css'
 ```
 
 ## EbayRadio with EbayLabel

--- a/src/ebay-radio/README.md
+++ b/src/ebay-radio/README.md
@@ -22,7 +22,7 @@ import "@ebay/skin/radio"
 
 ### or SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/radio/radio.css'
+import '@ebay/skin/radio.css'
 ```
 
 ## EbayRadio with EbayLabel

--- a/src/ebay-section-notice/README.md
+++ b/src/ebay-section-notice/README.md
@@ -17,14 +17,6 @@ import {
 
 ### Import following styles from SKIN
 
-#### Less files
-
-```less
-@import "~@ebay/skin/src/less/section-notice/ds6/section-notice.less";
-```
-
-#### JavaScript files
-
 ```jsx harmony
 import "@ebay/skin/section-notice";
 ```

--- a/src/ebay-select/README.md
+++ b/src/ebay-select/README.md
@@ -12,9 +12,9 @@ import { EbaySelect, EbaySelectOption } from '@ebay/ebayui-core-react/ebay-selec
 ```jsx harmony
 import '@ebay/skin/select';
 ```
-## Import styles using SCSS/CSS [Pending]
+## Import styles using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/select/select.css'
+import '@ebay/skin/select.css'
 ```
 
 ## Usage

--- a/src/ebay-select/README.md
+++ b/src/ebay-select/README.md
@@ -10,12 +10,11 @@ import { EbaySelect, EbaySelectOption } from '@ebay/ebayui-core-react/ebay-selec
 ```
 ## Import following styles from SKIN
 ```jsx harmony
-import '@ebay/skin/src/less/select/ds6/select.less';
-import '@ebay/skin/src/less/global/ds6/global.less';
+import '@ebay/skin/select';
 ```
 ## Import styles using SCSS/CSS [Pending]
 ```jsx harmony
-import '@ebay/skin/dist/ebay-select/ds6/select.css'
+import '@ebay/skin/dist/select/select.css'
 ```
 
 ## Usage

--- a/src/ebay-signal/README.md
+++ b/src/ebay-signal/README.md
@@ -19,14 +19,9 @@ import { EbaySignal } from '@ebay/ebayui-core-react/ebay-signal';
 import '@ebay/skin/signal'
 ```
 
-## or if using LESS:
-```jsx harmony
-import '@ebay/skin/signal[skin-ds6].less';
-```
-
 ## ...or using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/signal/ds6/signal.css'
+import '@ebay/skin/dist/signal/signal.css'
 ```
 
 ```jsx harmony

--- a/src/ebay-signal/README.md
+++ b/src/ebay-signal/README.md
@@ -21,7 +21,7 @@ import '@ebay/skin/signal'
 
 ## ...or using SCSS/CSS
 ```jsx harmony
-import '@ebay/skin/dist/signal/signal.css'
+import '@ebay/skin/signal.css'
 ```
 
 ```jsx harmony

--- a/src/ebay-switch/README.md
+++ b/src/ebay-switch/README.md
@@ -9,7 +9,7 @@ import { EbaySwitch } from '@ebay/ebayui-core-react/ebay-switch';
 ```
 ## Import following styles from SKIN
 ```jsx harmony
-import '@ebay/skin/src/less/switch/ds6/switch';
+import '@ebay/skin/switch';
 ```
 ## Usage
 ```

--- a/src/ebay-tooltip/README.md
+++ b/src/ebay-tooltip/README.md
@@ -17,7 +17,7 @@ import "@ebay/skin/tooltip"
 
 ### or if using SCSS/CSS
 ```jsx
-import "@ebay/skin/dist/tooltip/tooltip.css"
+import "@ebay/skin/tooltip.css"
 ```
 
 ## Usage

--- a/src/ebay-tooltip/README.md
+++ b/src/ebay-tooltip/README.md
@@ -17,7 +17,7 @@ import "@ebay/skin/tooltip"
 
 ### or if using SCSS/CSS
 ```jsx
-import "@ebay/skin/dist/tooltip/ds6/tooltip.css"
+import "@ebay/skin/dist/tooltip/tooltip.css"
 ```
 
 ## Usage

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,10 +1142,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@ebay/skin@^13.0.0", "@ebay/skin@^13.7.1":
-  version "13.7.1"
-  resolved "https://registry.yarnpkg.com/@ebay/skin/-/skin-13.7.1.tgz#0ff6c8acb30afaa8bc1eec62038d937eb7adc9ae"
-  integrity sha512-zrkHM2ERVpWl0W8fL8IWfo82HapCZ1raau5VzaqcBNZAQEfDs+EuByeUjYpeoFMNC0Aavnc/r3w59w9glewVTg==
+"@ebay/skin@^14":
+  version "14.0.5"
+  resolved "https://registry.yarnpkg.com/@ebay/skin/-/skin-14.0.5.tgz#430a3e4646f887c60465d4630c85e479053d139d"
+  integrity sha512-3Z8DRmFoJV8vpqpoEv5+Lasv/zypH7zK0b+UVyNoJa7ekOW9J1aK4lWxo6k0k3WF+gOkZUL/0+8rzHnQY57z5w==
 
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"


### PR DESCRIPTION
This will close issue #8 

The focus is to quickly support application upgrade to Skin v14:

- Update dependency to Skin v14
  * Remove resolutions from `package.json` since we will only use the latest Skin
- Fix storybook and make it runnable with Skin v14
  * Remove the part which force Market Sans loading. This is not necessary anymore since `import "@ebay/skin"` on storybook will include Market Sans
- Update README and component docs
  * Update CSS import path accordingly.
  * Remove LESS import directly from Skin `src`. This is to reduce maintenance efforts on our side when Skin source structure changes a lot.

## Not covered

The followings are not covered by this PR and will be tackled by separated PRs

- Update component API accordingly to eBay UI Core v9. There are a few breaking changes on their API changes, see https://github.com/eBay/ebayui-core/releases/tag/v9.0.0
- Tweak every components API and structure accordingly. Note that I did a quick manual regression test using Storybook and it looks 'ok' (no visual glitch). But there are some changes since Skin v14 or even Skin v13 which we haven't update on React version. For example our section notice with action still use button for action:

![Screenshot 2022-07-08 at 15 03 32](https://user-images.githubusercontent.com/1072047/177997373-5a9a2e67-ca87-46e7-8a87-8c0a288b7ded.png)

Meanwhile, since Skin v13, the section notice buttons have been replaced with simple link (see https://github.com/eBay/skin/pull/1469)

![Screenshot 2022-07-08 at 15 03 37](https://user-images.githubusercontent.com/1072047/177997403-c74bdaa9-99e5-495f-a827-06ea96ebfc82.png)

These changes need more efforts to do, might introduce breaking changes, and we need to iterate each components to make it up-to-date with the latest eBay Skin and eBay UI Core Marko.

- Icon generations. We can do this as a separated PR.

## Notes

I don't know how the release process will be but we should release this as a major version, preferable with beta or release candidates first.