### PR TITLE
ci: remove cache and move setup node action

### DIFF
--- a/.github/actions/analyze/action.yml
+++ b/.github/actions/analyze/action.yml
@@ -4,14 +4,6 @@ description: 'Composite analyze action'
 runs:
     using: "composite"
     steps:
-        - uses: actions/checkout@v3
-
-        - uses: actions/cache@v3
-          id: restore-node-modules
-          with:
-              path: ./node_modules
-              key: node-modules-${{ runner.os }}-${{ github.sha }}
-
         - name: Lint
           shell: sh
           run: yarn lint:ci

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,38 +1,11 @@
 name: "Action: Build"
 description: 'Composite build action'
 
-inputs:
-    node-version:
-        description: Node.js version
-        required: true
-
 runs:
     using: "composite"
     steps:
-        - name: Use Node.js ${{ inputs.node-version }}
-          uses: actions/setup-node@v3
-          with:
-              node-version: ${{ inputs.node-version }}
-              cache: 'yarn'
-
-        - name: Install dependencies
-          shell: sh
-          run: yarn --frozen-lockfile
-
-        - uses: actions/cache@v3
-          id: restore-node-modules
-          with:
-              path: ./node_modules
-              key: node-modules-${{ runner.os }}-${{ github.sha }}
-
         - name: Build library
           shell: sh
           run: |
             yarn build
             yarn copy
-
-        - uses: actions/cache@v3
-          id: restore-build
-          with:
-            path: ./lib
-            key: build-${{ runner.os }}-${{ github.sha }}

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -12,7 +12,6 @@ inputs:
 runs:
     using: "composite"
     steps:
-
         - name: Version bump
           uses: phips28/gh-action-bump-version@master
           env:
@@ -21,18 +20,6 @@ runs:
               major-wording: 'MAJOR,BREAKING CHANGE'
               minor-wording: 'MINOR,FEAT,CHORE'
               rc-wording: 'ALPHA,BETA'
-
-        - uses: actions/cache@v3
-          id: restore-node-modules
-          with:
-              path: ./node_modules
-              key: node-modules-${{ runner.os }}-${{ github.sha }}
-
-        - uses: actions/cache@v3
-          id: restore-build
-          with:
-              path: ./lib
-              key: build-${{ runner.os }}-${{ github.sha }}
 
         - name: Publish to NPM
           shell: sh

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,23 @@
+name: "Action: Setup node"
+description: 'Composite setup node action'
+
+inputs:
+    node-version:
+        description: Node.js version
+    node-version-file:
+        description: Use nvmrc file
+
+runs:
+    using: "composite"
+    steps:
+        - name: Use Node.js ${{ inputs.node-version }}
+          uses: actions/setup-node@v3
+          with:
+              node-version: ${{ inputs.node-version }}
+              node-version-file: ${{ inputs.node-version-file }}
+              cache: 'yarn'
+
+        - name: Install dependencies
+          shell: sh
+          run: yarn --frozen-lockfile
+

--- a/.github/actions/storybook/action.yml
+++ b/.github/actions/storybook/action.yml
@@ -10,17 +10,6 @@ inputs:
 runs:
     using: "composite"
     steps:
-        - uses: actions/checkout@v3
-
-        - uses: actions/setup-node@v3
-          with:
-              node-version: ${{ inputs.node-version }}
-              cache: 'yarn'
-
-        - name: Install dependencies
-          shell: sh
-          run: yarn --frozen-lockfile
-
         - name: Build Storybook
           shell: sh
           run: yarn build-storybook --output-dir storybook-static/${{ inputs.branch }}

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -2,9 +2,6 @@ name: "Action: Test"
 description: 'Composite test action'
 
 inputs:
-    node-version:
-        description: Node.js version
-        required: true
     with-coverage:
         description: Generate coverage reports
         required: false
@@ -13,17 +10,7 @@ inputs:
 runs:
     using: "composite"
     steps:
-        - uses: actions/checkout@v3
-
-        - uses: actions/cache@v3
-          id: restore-node-modules
-          with:
-              path: ./node_modules
-              key: node-modules-${{ runner.os }}-${{ github.sha }}
-
-        - shell: sh
-          run: yarn coverage
-
+        - run: yarn coverage
         - name: Coveralls
           if: inputs.with-coverage == 'true'
           uses: coverallsapp/github-action@master

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -10,7 +10,8 @@ inputs:
 runs:
     using: "composite"
     steps:
-        - run: yarn coverage
+        - shell: sh
+          run: yarn coverage
         - name: Coveralls
           if: inputs.with-coverage == 'true'
           uses: coverallsapp/github-action@master

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,9 +15,11 @@ jobs:
         steps:
             - uses: actions/checkout@v3
 
-            - uses: ./.github/actions/build
+            - uses: ./.github/actions/setup-node
               with:
                   node-version: ${{ matrix.node }}
+
+            - uses: ./.github/actions/build
 
             - uses: ./.github/actions/test
               with:
@@ -32,4 +34,7 @@ jobs:
             security-events: write
         steps:
             - uses: actions/checkout@v3
+            - uses: ./.github/actions/setup-node
+              with:
+                  node-version-file: '.nvmrc'
             - uses: ./.github/actions/analyze

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,9 +16,10 @@ jobs:
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v3
-            - uses: ./.github/actions/build
+            - uses: ./.github/actions/setup-node
               with:
                 node-version: ${{ matrix.node }}
+            - uses: ./.github/actions/build
             - uses: ./.github/actions/test
               with:
                 node-version: ${{ matrix.node }}
@@ -32,6 +33,9 @@ jobs:
             security-events: write
         steps:
             - uses: actions/checkout@v3
+            - uses: ./.github/actions/setup-node
+              with:
+                node-version-file: '.npmrc'
             - uses: ./.github/actions/analyze
 
     release:
@@ -40,9 +44,11 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
+            - uses: ./.github/actions/setup-node
+              with:
+                node-version-file: '.npmrc'
             - uses: ./.github/actions/release
               with:
-                node-version: 16.13.2
                 githubToken: ${{ github.token }}
                 npmToken: ${{ secrets.NPM_TOKEN }}
 
@@ -52,6 +58,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
+            - uses: ./.github/actions/setup-node
+              with:
+                node-version-file: '.npmrc'
             - uses: ./.github/actions/storybook
               with:
                 branch: main


### PR DESCRIPTION
- Use yarn cache instead of caching `node_modules`. There is a [suggestion](https://github.com/actions/cache/blob/main/examples.md#node---npm) to not cache node_modules folder
- Move node setup to a separate action so can be re-used
- Use `uses: actions/checkout@v3` only on workflow setup