### PR TITLE
FIX: EbayInfotip focus host on closing infotip

### DIFF
--- a/src/common/tooltip-utils/use-tooltip.ts
+++ b/src/common/tooltip-utils/use-tooltip.ts
@@ -1,18 +1,19 @@
-import { useState } from 'react'
+import { useState, RefObject } from 'react'
 
 type UseTooltipArgs = {
     onExpand: () => void;
     onCollapse: () => void;
     initialExpanded?: boolean;
-}
+    hostRef?: RefObject<HTMLElement>;
+};
 
 type UseTooltip = {
     isExpanded: boolean;
     expandTooltip: () => void;
     collapseTooltip: () => void;
-}
+};
 
-export const useTooltip = ({ onExpand, onCollapse, initialExpanded = false }: UseTooltipArgs): UseTooltip => {
+export const useTooltip = ({ onExpand, onCollapse, initialExpanded = false, hostRef }: UseTooltipArgs): UseTooltip => {
     const [isExpanded, setIsExpanded] = useState(initialExpanded)
     const expandTooltip = () => {
         setIsExpanded(true)
@@ -25,6 +26,10 @@ export const useTooltip = ({ onExpand, onCollapse, initialExpanded = false }: Us
         setIsExpanded(false)
         if (onCollapse) {
             onCollapse()
+        }
+
+        if (hostRef?.current) {
+            hostRef.current.focus()
         }
     }
 

--- a/src/common/tooltip-utils/use-tooltip.ts
+++ b/src/common/tooltip-utils/use-tooltip.ts
@@ -28,9 +28,7 @@ export const useTooltip = ({ onExpand, onCollapse, initialExpanded = false, host
             onCollapse()
         }
 
-        if (hostRef?.current) {
-            hostRef.current.focus()
-        }
+        hostRef?.current?.focus()
     }
 
     return {

--- a/src/ebay-infotip/__tests__/index.spec.tsx
+++ b/src/ebay-infotip/__tests__/index.spec.tsx
@@ -83,6 +83,26 @@ describe('<EbayInfotip>', () => {
 
             expect(wrapper.container.querySelector('.infotip__close[aria-label="Dismiss info"]')).toBeInTheDocument()
         })
+
+        it('should focus the button element', () => {
+            const { getByLabelText } = render(
+                <EbayInfotip a11yCloseText="Dismiss info" aria-label="info">
+                    <EbayInfotipContent>
+                        <p>Info content</p>
+                    </EbayInfotipContent>
+                </EbayInfotip>
+            )
+
+            const host = getByLabelText('info')
+
+            fireEvent.click(host)
+            expect(host).not.toHaveFocus()
+
+            const close = getByLabelText('Dismiss info')
+
+            fireEvent.click(close)
+            expect(host).toHaveFocus()
+        })
     })
 })
 

--- a/src/ebay-infotip/ebay-infotip.tsx
+++ b/src/ebay-infotip/ebay-infotip.tsx
@@ -38,11 +38,12 @@ const EbayInfotip: FC<InfotipProps> = ({
     'aria-label': ariaLabel,
     className
 }) => {
+    const buttonRef = useRef()
     const {
         isExpanded,
         expandTooltip,
         collapseTooltip
-    } = useTooltip({ onCollapse, onExpand, initialExpanded })
+    } = useTooltip({ onCollapse, onExpand, initialExpanded, hostRef: buttonRef })
 
     const isModal = variant === 'modal'
     const containerRef = useRef()
@@ -72,6 +73,7 @@ const EbayInfotip: FC<InfotipProps> = ({
             ref={containerRef}>
             <TooltipHost>
                 {cloneElement(button, {
+                    ref: buttonRef,
                     onClick: toggleTooltip,
                     disabled,
                     variant,


### PR DESCRIPTION
- Add a `hostRef` on `useTooltip` and focus on it on collapse

Fix #67 