### PR TITLE
FIX: EbayTabs duplicated ids

### DIFF
--- a/src/ebay-tabs/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-tabs/__tests__/__snapshots__/index.spec.tsx.snap
@@ -436,6 +436,223 @@ exports[`Storyshots ebay-tab Manually activated Tabs 1`] = `
 </DocumentFragment>
 `;
 
+exports[`Storyshots ebay-tab Multiple Tabs 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="tabs"
+      id="tab-upper"
+    >
+      <div
+        class="tabs__items"
+        role="tablist"
+      >
+        <div
+          aria-controls="tab-upper-tabpanel-0"
+          aria-selected="true"
+          class="tabs__item"
+          id="tab-upper-tab-0"
+          role="tab"
+          tabindex="0"
+        >
+          <span>
+            Tab 1
+          </span>
+        </div>
+        <div
+          aria-controls="tab-upper-tabpanel-1"
+          aria-selected="false"
+          class="tabs__item"
+          id="tab-upper-tab-1"
+          role="tab"
+          tabindex="-1"
+        >
+          <span>
+            Tab 2
+          </span>
+        </div>
+      </div>
+      <div
+        class="tabs__content"
+      >
+        <div
+          aria-labelledby="default-tab-0"
+          class="tabs__panel"
+          id="tab-upper-tabpanel-0"
+          role="tabpanel"
+        >
+          <div
+            class="tabs__cell"
+          >
+            <h3>
+              Panel 1
+            </h3>
+            <p>
+              Panel 1 content. Here is a 
+              <a
+                href="#"
+              >
+                link
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+        <div
+          aria-labelledby="default-tab-1"
+          class="tabs__panel"
+          hidden=""
+          id="tab-upper-tabpanel-1"
+          role="tabpanel"
+        >
+          <div
+            class="tabs__cell"
+          >
+            <h3>
+              Panel 2
+            </h3>
+            <p>
+              Panel 2 content. Here is a 
+              <a
+                href="#"
+              >
+                link
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    style="margin-top: 64px;"
+  >
+    <div
+      class="tabs"
+      id="tab-lower"
+    >
+      <div
+        class="tabs__items"
+        role="tablist"
+      >
+        <div
+          aria-controls="tab-lower-tabpanel-0"
+          aria-selected="true"
+          class="tabs__item"
+          id="tab-lower-tab-0"
+          role="tab"
+          tabindex="0"
+        >
+          <span>
+            Tab A
+          </span>
+        </div>
+        <div
+          aria-controls="tab-lower-tabpanel-1"
+          aria-selected="false"
+          class="tabs__item"
+          id="tab-lower-tab-1"
+          role="tab"
+          tabindex="-1"
+        >
+          <span>
+            Tab B
+          </span>
+        </div>
+        <div
+          aria-controls="tab-lower-tabpanel-2"
+          aria-selected="false"
+          class="tabs__item"
+          id="tab-lower-tab-2"
+          role="tab"
+          tabindex="-1"
+        >
+          <span>
+            Tab C
+          </span>
+        </div>
+      </div>
+      <div
+        class="tabs__content"
+      >
+        <div
+          aria-labelledby="default-tab-0"
+          class="tabs__panel"
+          id="tab-lower-tabpanel-0"
+          role="tabpanel"
+        >
+          <div
+            class="tabs__cell"
+          >
+            <h3>
+              Panel A
+            </h3>
+            <p>
+              Panel A content. Here is a 
+              <a
+                href="#"
+              >
+                link
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+        <div
+          aria-labelledby="default-tab-1"
+          class="tabs__panel"
+          hidden=""
+          id="tab-lower-tabpanel-1"
+          role="tabpanel"
+        >
+          <div
+            class="tabs__cell"
+          >
+            <h3>
+              Panel B
+            </h3>
+            <p>
+              Panel B content. Here is a 
+              <a
+                href="#"
+              >
+                link
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+        <div
+          aria-labelledby="default-tab-2"
+          class="tabs__panel"
+          hidden=""
+          id="tab-lower-tabpanel-2"
+          role="tabpanel"
+        >
+          <div
+            class="tabs__cell"
+          >
+            <h3>
+              Panel C
+            </h3>
+            <p>
+              Panel C content. Here is a 
+              <a
+                href="#"
+              >
+                link
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
 exports[`Storyshots ebay-tab Pre-selected Tab 1`] = `
 <DocumentFragment>
   <div

--- a/src/ebay-tabs/__tests__/index.stories.tsx
+++ b/src/ebay-tabs/__tests__/index.stories.tsx
@@ -4,12 +4,6 @@ import { action } from '../../../.storybook/action'
 
 import { EbayTabs, EbayTab as Tab, EbayTabPanel as Panel } from '../index'
 
-const disableInfo = {
-    info: {
-        disable: true // disable info addon cause it throws an error
-    }
-}
-
 storiesOf('ebay-tab', module)
     .add('Default Tabs', () => (<>
         <EbayTabs onTabSelect={action('tab selected')}>
@@ -35,7 +29,7 @@ storiesOf('ebay-tab', module)
                 </p>
             </Panel>
         </EbayTabs>
-    </>), disableInfo)
+    </>))
     .add('Pre-selected Tab', () => (<>
         <EbayTabs index={2}>
             <Tab>Tab 1</Tab>
@@ -60,7 +54,7 @@ storiesOf('ebay-tab', module)
                 </p>
             </Panel>
         </EbayTabs>
-    </>), disableInfo )
+    </>) )
     .add('Programmatically selected Tabs', () => {
         const Component = () => {
             const [selectedTab, selectTab] = useState(0)
@@ -79,7 +73,7 @@ storiesOf('ebay-tab', module)
         }
 
         return <><Component /></>
-    }, disableInfo )
+    } )
     .add('Fake Tabs (links)', () => (<>
         <EbayTabs>
             <Tab href="https://www.ebay.com/1">Tab 1</Tab>
@@ -93,7 +87,7 @@ storiesOf('ebay-tab', module)
                 </p>
             </Panel>
         </EbayTabs>
-    </>), disableInfo)
+    </>))
     .add('Manually activated Tabs', () => (<>
         <EbayTabs activation="manual">
             <Tab>Tab 1</Tab>
@@ -121,7 +115,7 @@ storiesOf('ebay-tab', module)
                 </p>
             </Panel>
         </EbayTabs>
-    </>), disableInfo)
+    </>))
     .add('Large Tabs', () => (<>
         <EbayTabs size="large">
             <Tab>Large Tab 1</Tab>
@@ -146,4 +140,39 @@ storiesOf('ebay-tab', module)
                 </p>
             </Panel>
         </EbayTabs>
-    </>), disableInfo)
+    </>))
+    .add('Multiple Tabs', () => (<>
+        <div>
+            <EbayTabs id="tab-upper">
+                <Tab>Tab 1</Tab>
+                <Tab>Tab 2</Tab>
+                <Panel>
+                    <h3>Panel 1</h3>
+                    <p>Panel 1 content. Here is a <a href="#">link</a>.</p>
+                </Panel>
+                <Panel>
+                    <h3>Panel 2</h3>
+                    <p>Panel 2 content. Here is a <a href="#">link</a>.</p>
+                </Panel>
+            </EbayTabs>
+        </div>
+        <div style={{marginTop: '64px'}}>
+            <EbayTabs id="tab-lower">
+                <Tab>Tab A</Tab>
+                <Tab>Tab B</Tab>
+                <Tab>Tab C</Tab>
+                <Panel>
+                    <h3>Panel A</h3>
+                    <p>Panel A content. Here is a <a href="#">link</a>.</p>
+                </Panel>
+                <Panel>
+                    <h3>Panel B</h3>
+                    <p>Panel B content. Here is a <a href="#">link</a>.</p>
+                </Panel>
+                <Panel>
+                    <h3>Panel C</h3>
+                    <p>Panel C content. Here is a <a href="#">link</a>.</p>
+                </Panel>
+            </EbayTabs>
+        </div>
+    </>))

--- a/src/ebay-tabs/tab-panel.tsx
+++ b/src/ebay-tabs/tab-panel.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 
 type TabPanelProps = ComponentProps<'div'> & {
     index?: number;
+    parentId?: string;
     selected?: boolean;
     fake?: boolean;
 }
@@ -10,6 +11,7 @@ type TabPanelProps = ComponentProps<'div'> & {
 const TabPanel: FC<TabPanelProps> = ({
     children,
     index,
+    parentId,
     selected,
     fake,
     className,
@@ -24,7 +26,7 @@ const TabPanel: FC<TabPanelProps> = ({
             {...rest}
             aria-labelledby={`default-tab-${index}`}
             className={classNames(className, 'tabs__panel')}
-            id={`default-tabpanel-${index}`}
+            id={`${parentId || 'default'}-tabpanel-${index}`}
             role="tabpanel"
             hidden={!selected}
         >

--- a/src/ebay-tabs/tab.tsx
+++ b/src/ebay-tabs/tab.tsx
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 
 type TabProps = ComponentProps<'li'> & ComponentProps<'div'> & {
     index?: number;
+    parentId?: string;
     selected?: boolean;
     href?: string;
     onClick?: () => void;
@@ -13,6 +14,7 @@ type TabProps = ComponentProps<'li'> & ComponentProps<'div'> & {
 const Tab: FC<TabProps> = ({
     children,
     index,
+    parentId,
     selected,
     href,
     className,
@@ -31,10 +33,10 @@ const Tab: FC<TabProps> = ({
         <div
             {...rest}
             ref={refCallback}
-            aria-controls={`default-tabpanel-${index}`}
+            aria-controls={`${parentId || 'default'}-tabpanel-${index}`}
             aria-selected={selected}
             className={classNames(className, 'tabs__item')}
-            id={`default-tab-${index}`}
+            id={`${parentId || 'default'}-tab-${index}`}
             role="tab"
             tabIndex={selected ? 0 : -1}
             onClick={onClick}

--- a/src/ebay-tabs/tabs.tsx
+++ b/src/ebay-tabs/tabs.tsx
@@ -87,6 +87,7 @@ class Tabs extends Component<TabsProps, State> {
 
     render(): ReactElement {
         const {
+            id,
             className,
             size = 'medium',
             children
@@ -99,6 +100,7 @@ class Tabs extends Component<TabsProps, State> {
             const itemProps = {
                 refCallback: ref => { this.headings[i] = ref },
                 index: i,
+                parentId: id,
                 selected: this.state.selectedIndex === i,
                 href,
                 children: content,
@@ -113,6 +115,7 @@ class Tabs extends Component<TabsProps, State> {
             const { children: content } = item.props
             const itemProps = {
                 index: i,
+                parentId: id,
                 selected: this.state.selectedIndex === i,
                 fake,
                 children: content
@@ -122,7 +125,7 @@ class Tabs extends Component<TabsProps, State> {
         })
 
         return fake ? (
-            <div className={classNames(className, 'fake-tabs')}>
+            <div id={id} className={classNames(className, 'fake-tabs')}>
                 <ul className={classNames('fake-tabs__items', { 'fake-tabs__items--large': large })}>
                     {tabHeadings}
                 </ul>
@@ -131,7 +134,7 @@ class Tabs extends Component<TabsProps, State> {
                 </div>
             </div>
         ) : (
-            <div className={classNames(className, 'tabs')}>
+            <div id={id} className={classNames(className, 'tabs')}>
                 <div className={classNames('tabs__items', { 'tabs__items--large': large })} role="tablist">
                     {tabHeadings}
                 </div>


### PR DESCRIPTION
This PR will fix issue #72 (when there are more than 1 ebay-tabs on a page, the page will get accessibility error due to duplicated IDs). The solution is to support prop `id` on EbayTab which will be used to generate IDs for the nesting components (tab headers and tab panels).

Others:

- Remove disable info on EbayTabs Storybook as we don't use Storybook info addons anymore.
- Add new storybook with multiple tabs

NOTE: This is a quick fix since I did not have time to refactor the component into React hooks nor updating its storybook to use CSF format.