### PR TITLE
Fix tab header stealing focus from inputs

### DIFF
--- a/src/ebay-tabs/__tests__/index.stories.tsx
+++ b/src/ebay-tabs/__tests__/index.stories.tsx
@@ -176,3 +176,25 @@ storiesOf('ebay-tab', module)
             </EbayTabs>
         </div>
     </>))
+    .add('Tabs with inputs', () => {
+        const Component = () => {
+            const [name, setName] = useState('John Doe')
+
+            return (
+                <EbayTabs>
+                    <Tab>Tab 1</Tab>
+                    <Tab>Tab 2</Tab>
+                    <Tab>Tab 3</Tab>
+                    <Panel>
+                        <label htmlFor='name'>Name </label>
+                        <input id='name' onChange={(e) => setName(e.target.value)} type='text' placeholder='john doe' value={name} />
+                        <p>My name is {name}</p>
+                    </Panel>
+                    <Panel><h3>Panel 2</h3></Panel>
+                    <Panel><h3>Panel 3</h3></Panel>
+                </EbayTabs>
+            )
+        }
+
+        return <><Component /></>
+    } )

--- a/src/ebay-tabs/tabs.tsx
+++ b/src/ebay-tabs/tabs.tsx
@@ -42,8 +42,8 @@ class Tabs extends Component<TabsProps, State> {
     componentDidUpdate(prevProps: TabsProps): void {
         if (this.props.index !== prevProps.index) {
             this.onTabSelect(this.props.index)
+            this.headings[this.state.focusedIndex]?.focus()
         }
-        this.headings[this.state.focusedIndex]?.focus()
     }
 
     onTabSelect(i: number): void {


### PR DESCRIPTION
**Problem statement:** When Tabs component's props are updated, the tab header is programmatically set in focus.

**Problem use case:** Text input element within the tab body is updated by the user which results in updating the global state. The global state is then updated and propagated back down to the tabs component. Since the Tabs component sees that a prop is updated, it will take the focus from the text input and set it on the tab header.

Changes:
- Only focus on tab header when there is an update and the tab indexes have changed
- Added new storybook example with text input (similar use case as described above)