### PR TITLE
FIX: Remove react-focus-lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "classnames": "^2.2.6",
     "makeup-keyboard-trap": "^0.4.1",
     "makeup-screenreader-trap": "^0.4.1",
-    "react-focus-lock": "^2.9.1",
     "react-remove-scroll": "^2.2.0"
   },
   "devDependencies": {

--- a/src/ebay-alert-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-alert-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -17,24 +17,23 @@ exports[`Storyshots ebay-alert-dialog Default 1`] = `
       Some outside content...
     </p>
     <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
       aria-hidden="false"
-      data-focus-lock-disabled="false"
     >
       <div
         aria-hidden="false"
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="alert-dialog alert-dialog--mask-fade"
+        role="alertdialog"
       >
         <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
+        <div
           aria-hidden="false"
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="alert-dialog alert-dialog--mask-fade"
-          role="alertdialog"
+          class="alert-dialog__window alert-dialog__window--fade keyboard-trap--active"
         >
           <div
             aria-hidden="true"
@@ -42,54 +41,39 @@ exports[`Storyshots ebay-alert-dialog Default 1`] = `
             tabindex="0"
           />
           <div
-            aria-hidden="false"
-            class="alert-dialog__window alert-dialog__window--fade keyboard-trap--active"
+            class="alert-dialog__header"
           >
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
-            <div
-              class="alert-dialog__header"
+            <h2
+              id="dialog-title-abc123"
             >
-              <h2
-                id="dialog-title-abc123"
+              Heading
+            </h2>
+          </div>
+          <div
+            class="alert-dialog__main"
+            id="alert-dialog-main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              <a
+                href="http://www.ebay.com"
               >
-                Heading
-              </h2>
-            </div>
-            <div
-              class="alert-dialog__main"
-              id="alert-dialog-main"
+                www.ebay.com
+              </a>
+            </p>
+          </div>
+          <div
+            class="alert-dialog__footer"
+          >
+            <button
+              aria-describedby="alert-dialog-main"
+              class="btn alert-dialog__acknowledge btn--primary"
+              id="alert-dialog-confirm"
             >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                <a
-                  href="http://www.ebay.com"
-                >
-                  www.ebay.com
-                </a>
-              </p>
-            </div>
-            <div
-              class="alert-dialog__footer"
-            >
-              <button
-                aria-describedby="alert-dialog-main"
-                class="btn alert-dialog__acknowledge btn--primary"
-                id="alert-dialog-confirm"
-              >
-                Confirm
-              </button>
-            </div>
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
+              Confirm
+            </button>
           </div>
           <div
             aria-hidden="true"
@@ -97,14 +81,13 @@ exports[`Storyshots ebay-alert-dialog Default 1`] = `
             tabindex="0"
           />
         </div>
+        <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;
@@ -120,69 +103,55 @@ exports[`Storyshots ebay-alert-dialog With Animation 1`] = `
     <p>
       Some outside content...
     </p>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
-      <div>
+    <div>
+      <div
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="alert-dialog alert-dialog--mask-fade"
+        hidden=""
+        role="alertdialog"
+      >
         <div
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="alert-dialog alert-dialog--mask-fade"
-          hidden=""
-          role="alertdialog"
+          class="alert-dialog__window alert-dialog__window alert-dialog__window--fade"
         >
           <div
-            class="alert-dialog__window alert-dialog__window alert-dialog__window--fade"
+            class="alert-dialog__header"
           >
-            <div
-              class="alert-dialog__header"
+            <h2
+              id="dialog-title-abc123"
             >
-              <h2
-                id="dialog-title-abc123"
+              Heading
+            </h2>
+          </div>
+          <div
+            class="alert-dialog__main"
+            id="alert-dialog-main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              <a
+                href="http://www.ebay.com"
               >
-                Heading
-              </h2>
-            </div>
-            <div
-              class="alert-dialog__main"
-              id="alert-dialog-main"
+                www.ebay.com
+              </a>
+            </p>
+          </div>
+          <div
+            class="alert-dialog__footer"
+          >
+            <button
+              aria-describedby="alert-dialog-main"
+              class="btn alert-dialog__acknowledge btn--primary"
+              id="alert-dialog-confirm"
             >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                <a
-                  href="http://www.ebay.com"
-                >
-                  www.ebay.com
-                </a>
-              </p>
-            </div>
-            <div
-              class="alert-dialog__footer"
-            >
-              <button
-                aria-describedby="alert-dialog-main"
-                class="btn alert-dialog__acknowledge btn--primary"
-                id="alert-dialog-confirm"
-              >
-                Confirm
-              </button>
-            </div>
+              Confirm
+            </button>
           </div>
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;

--- a/src/ebay-confirm-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-confirm-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -17,24 +17,23 @@ exports[`Storyshots ebay-confirm-dialog Default 1`] = `
       Some outside content...
     </p>
     <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
       aria-hidden="false"
-      data-focus-lock-disabled="false"
     >
       <div
         aria-hidden="false"
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="confirm-dialog confirm-dialog--mask-fade"
+        role="dialog"
       >
         <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
+        <div
           aria-hidden="false"
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="confirm-dialog confirm-dialog--mask-fade"
-          role="dialog"
+          class="confirm-dialog__window confirm-dialog__window--fade keyboard-trap--active"
         >
           <div
             aria-hidden="true"
@@ -42,52 +41,37 @@ exports[`Storyshots ebay-confirm-dialog Default 1`] = `
             tabindex="0"
           />
           <div
-            aria-hidden="false"
-            class="confirm-dialog__window confirm-dialog__window--fade keyboard-trap--active"
+            class="confirm-dialog__header"
           >
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
-            <div
-              class="confirm-dialog__header"
+            <h2
+              id="dialog-title-abc123"
             >
-              <h2
-                id="dialog-title-abc123"
-              >
-                Delete Address?
-              </h2>
-            </div>
-            <div
-              class="confirm-dialog__main"
-              id="confirm-dialog-main"
+              Delete Address?
+            </h2>
+          </div>
+          <div
+            class="confirm-dialog__main"
+            id="confirm-dialog-main"
+          >
+            <p>
+              You will permanently lose this address.
+            </p>
+          </div>
+          <div
+            class="confirm-dialog__footer"
+          >
+            <button
+              class="btn confirm-dialog__reject btn--secondary"
             >
-              <p>
-                You will permanently lose this address.
-              </p>
-            </div>
-            <div
-              class="confirm-dialog__footer"
+              Delete
+            </button>
+            <button
+              aria-describedby="confirm-dialog-main"
+              class="btn confirm-dialog__confirm btn--primary"
+              id="confirm-dialog-confirm"
             >
-              <button
-                class="btn confirm-dialog__reject btn--secondary"
-              >
-                Delete
-              </button>
-              <button
-                aria-describedby="confirm-dialog-main"
-                class="btn confirm-dialog__confirm btn--primary"
-                id="confirm-dialog-confirm"
-              >
-                Cancel
-              </button>
-            </div>
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
+              Cancel
+            </button>
           </div>
           <div
             aria-hidden="true"
@@ -95,14 +79,13 @@ exports[`Storyshots ebay-confirm-dialog Default 1`] = `
             tabindex="0"
           />
         </div>
+        <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;
@@ -118,67 +101,53 @@ exports[`Storyshots ebay-confirm-dialog With Animation 1`] = `
     <p>
       Some outside content...
     </p>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
-      <div>
+    <div>
+      <div
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="confirm-dialog confirm-dialog--mask-fade"
+        hidden=""
+        role="dialog"
+      >
         <div
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="confirm-dialog confirm-dialog--mask-fade"
-          hidden=""
-          role="dialog"
+          class="confirm-dialog__window confirm-dialog__window confirm-dialog__window--fade"
         >
           <div
-            class="confirm-dialog__window confirm-dialog__window confirm-dialog__window--fade"
+            class="confirm-dialog__header"
           >
-            <div
-              class="confirm-dialog__header"
+            <h2
+              id="dialog-title-abc123"
             >
-              <h2
-                id="dialog-title-abc123"
-              >
-                Delete Address?
-              </h2>
-            </div>
-            <div
-              class="confirm-dialog__main"
-              id="confirm-dialog-main"
+              Delete Address?
+            </h2>
+          </div>
+          <div
+            class="confirm-dialog__main"
+            id="confirm-dialog-main"
+          >
+            <p>
+              You will permanently lose this address.
+            </p>
+          </div>
+          <div
+            class="confirm-dialog__footer"
+          >
+            <button
+              class="btn confirm-dialog__reject btn--secondary"
             >
-              <p>
-                You will permanently lose this address.
-              </p>
-            </div>
-            <div
-              class="confirm-dialog__footer"
+              Delete
+            </button>
+            <button
+              aria-describedby="confirm-dialog-main"
+              class="btn confirm-dialog__confirm btn--primary"
+              id="confirm-dialog-confirm"
             >
-              <button
-                class="btn confirm-dialog__reject btn--secondary"
-              >
-                Delete
-              </button>
-              <button
-                aria-describedby="confirm-dialog-main"
-                class="btn confirm-dialog__confirm btn--primary"
-                id="confirm-dialog-confirm"
-              >
-                Cancel
-              </button>
-            </div>
+              Cancel
+            </button>
           </div>
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;

--- a/src/ebay-dialog-base/dialog-base-with-state.tsx
+++ b/src/ebay-dialog-base/dialog-base-with-state.tsx
@@ -1,5 +1,4 @@
 import React, { Children, ReactElement } from 'react'
-import FocusLock from 'react-focus-lock'
 import { RemoveScroll } from 'react-remove-scroll'
 import { DialogBase, DialogBaseProps } from './components/dialogBase'
 import { EbayDialogCloseButton, EbayDialogFooter, EbayDialogHeader } from './index'
@@ -35,11 +34,9 @@ export const DialogBaseWithState = ({
     )
 
     const renderOverLay = () => shouldRenderModal ? (
-        <FocusLock returnFocus={{ preventScroll: false }}>
-            <RemoveScroll enabled={open}>
-                {dialogBase}
-            </RemoveScroll>
-        </FocusLock>
+        <RemoveScroll enabled={open}>
+            {dialogBase}
+        </RemoveScroll>
     ) : dialogBase
 
     return animated || open ? renderOverLay() : null

--- a/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -333,86 +333,70 @@ exports[`Storyshots ebay-drawer-dialog Lots Of Content 1`] = `
 exports[`Storyshots ebay-drawer-dialog Opened 1`] = `
 <DocumentFragment>
   <div
-    aria-hidden="true"
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
-  <div
     aria-hidden="false"
-    data-focus-lock-disabled="false"
   >
     <div
       aria-hidden="false"
+      aria-labelledby="dialog-title-abc123"
+      arial-modal="true"
+      class="drawer-dialog drawer-dialog--mask-fade-slow"
+      role="dialog"
     >
       <div
+        aria-hidden="true"
+        class="keyboard-trap-boundary"
+        tabindex="0"
+      />
+      <div
         aria-hidden="false"
-        aria-labelledby="dialog-title-abc123"
-        arial-modal="true"
-        class="drawer-dialog drawer-dialog--mask-fade-slow"
-        role="dialog"
+        class="drawer-dialog__window drawer-dialog__window--slide keyboard-trap--active"
       >
         <div
           aria-hidden="true"
           class="keyboard-trap-boundary"
           tabindex="0"
         />
+        <button
+          aria-label="Maximize Drawer"
+          class="drawer-dialog__handle"
+        />
         <div
-          aria-hidden="false"
-          class="drawer-dialog__window drawer-dialog__window--slide keyboard-trap--active"
+          class="drawer-dialog__header"
         >
-          <div
-            aria-hidden="true"
-            class="keyboard-trap-boundary"
-            tabindex="0"
+          <h2
+            id="dialog-title-abc123"
           />
           <button
-            aria-label="Maximize Drawer"
-            class="drawer-dialog__handle"
-          />
-          <div
-            class="drawer-dialog__header"
+            class="icon-btn drawer-dialog__close"
+            type="button"
           >
-            <h2
-              id="dialog-title-abc123"
-            />
-            <button
-              class="icon-btn drawer-dialog__close"
-              type="button"
+            <svg
+              aria-hidden="true"
+              class="icon icon--close"
+              focusable="false"
+              height="24px"
+              width="24px"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-hidden="true"
-                class="icon icon--close"
-                focusable="false"
-                height="24px"
-                width="24px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <use
-                  xlink:href="#icon-close"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="drawer-dialog__main"
-          >
-            <p>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-            </p>
-            <p>
-              <a
-                href="http://www.ebay.com"
-              >
-                www.ebay.com
-              </a>
-            </p>
-          </div>
-          <div
-            aria-hidden="true"
-            class="keyboard-trap-boundary"
-            tabindex="0"
-          />
+              <use
+                xlink:href="#icon-close"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          class="drawer-dialog__main"
+        >
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+          <p>
+            <a
+              href="http://www.ebay.com"
+            >
+              www.ebay.com
+            </a>
+          </p>
         </div>
         <div
           aria-hidden="true"
@@ -420,14 +404,13 @@ exports[`Storyshots ebay-drawer-dialog Opened 1`] = `
           tabindex="0"
         />
       </div>
+      <div
+        aria-hidden="true"
+        class="keyboard-trap-boundary"
+        tabindex="0"
+      />
     </div>
   </div>
-  <div
-    aria-hidden="true"
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
 </DocumentFragment>
 `;
 
@@ -438,76 +421,62 @@ exports[`Storyshots ebay-drawer-dialog With Animation 1`] = `
   >
     Open Drawer
   </button>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
-  <div
-    data-focus-lock-disabled="false"
-  >
-    <div>
+  <div>
+    <div
+      aria-labelledby="dialog-title-abc123"
+      arial-modal="true"
+      class="drawer-dialog drawer-dialog--mask-fade-slow"
+      hidden=""
+      role="dialog"
+    >
       <div
-        aria-labelledby="dialog-title-abc123"
-        arial-modal="true"
-        class="drawer-dialog drawer-dialog--mask-fade-slow"
-        hidden=""
-        role="dialog"
+        class="drawer-dialog__window drawer-dialog__window drawer-dialog__window--slide"
       >
+        <button
+          aria-label="Maximize Drawer"
+          class="drawer-dialog__handle"
+        />
         <div
-          class="drawer-dialog__window drawer-dialog__window drawer-dialog__window--slide"
+          class="drawer-dialog__header"
         >
-          <button
-            aria-label="Maximize Drawer"
-            class="drawer-dialog__handle"
+          <h2
+            id="dialog-title-abc123"
           />
-          <div
-            class="drawer-dialog__header"
+          <button
+            class="icon-btn drawer-dialog__close"
+            type="button"
           >
-            <h2
-              id="dialog-title-abc123"
-            />
-            <button
-              class="icon-btn drawer-dialog__close"
-              type="button"
+            <svg
+              aria-hidden="true"
+              class="icon icon--close"
+              focusable="false"
+              height="24px"
+              width="24px"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-hidden="true"
-                class="icon icon--close"
-                focusable="false"
-                height="24px"
-                width="24px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <use
-                  xlink:href="#icon-close"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="drawer-dialog__main"
-          >
-            <p>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-            </p>
-            <p>
-              <a
-                href="http://www.ebay.com"
-              >
-                www.ebay.com
-              </a>
-            </p>
-          </div>
+              <use
+                xlink:href="#icon-close"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          class="drawer-dialog__main"
+        >
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+          <p>
+            <a
+              href="http://www.ebay.com"
+            >
+              www.ebay.com
+            </a>
+          </p>
         </div>
       </div>
     </div>
   </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
 </DocumentFragment>
 `;
 

--- a/src/ebay-fullscreen-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-fullscreen-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -11,24 +11,23 @@ exports[`Storyshots ebay-fullscreen-dialog Always Opened 1`] = `
       Some outside content...
     </p>
     <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
       aria-hidden="false"
-      data-focus-lock-disabled="false"
     >
       <div
         aria-hidden="false"
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="fullscreen-dialog fullscreen-dialog--mask-fade-slow"
+        role="dialog"
       >
         <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
+        <div
           aria-hidden="false"
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="fullscreen-dialog fullscreen-dialog--mask-fade-slow"
-          role="dialog"
+          class="fullscreen-dialog__window fullscreen-dialog__window--slide keyboard-trap--active"
         >
           <div
             aria-hidden="true"
@@ -36,64 +35,49 @@ exports[`Storyshots ebay-fullscreen-dialog Always Opened 1`] = `
             tabindex="0"
           />
           <div
-            aria-hidden="false"
-            class="fullscreen-dialog__window fullscreen-dialog__window--slide keyboard-trap--active"
+            class="fullscreen-dialog__header"
           >
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
-            <div
-              class="fullscreen-dialog__header"
+            <button
+              class="icon-btn fullscreen-dialog__close"
+              type="button"
             >
-              <button
-                class="icon-btn fullscreen-dialog__close"
-                type="button"
+              <svg
+                aria-hidden="true"
+                class="icon icon--close"
+                focusable="false"
+                height="24px"
+                width="24px"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  class="icon icon--close"
-                  focusable="false"
-                  height="24px"
-                  width="24px"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <use
-                    xlink:href="#icon-close"
-                  />
-                </svg>
-              </button>
-              <h2
-                id="dialog-title-abc123"
+                <use
+                  xlink:href="#icon-close"
+                />
+              </svg>
+            </button>
+            <h2
+              id="dialog-title-abc123"
+            >
+              Heading
+            </h2>
+          </div>
+          <div
+            class="fullscreen-dialog__main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              <a
+                href="http://www.ebay.com"
               >
-                Heading
-              </h2>
-            </div>
-            <div
-              class="fullscreen-dialog__main"
-            >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                <a
-                  href="http://www.ebay.com"
-                >
-                  www.ebay.com
-                </a>
-              </p>
-            </div>
-            <div
-              class="fullscreen-dialog__footer"
-            >
-              ©2021 eBay
-            </div>
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
+                www.ebay.com
+              </a>
+            </p>
+          </div>
+          <div
+            class="fullscreen-dialog__footer"
+          >
+            ©2021 eBay
           </div>
           <div
             aria-hidden="true"
@@ -101,14 +85,13 @@ exports[`Storyshots ebay-fullscreen-dialog Always Opened 1`] = `
             tabindex="0"
           />
         </div>
+        <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;
@@ -139,74 +122,60 @@ exports[`Storyshots ebay-fullscreen-dialog With Animation 1`] = `
     <p>
       Some outside content...
     </p>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
-      <div>
+    <div>
+      <div
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="fullscreen-dialog fullscreen-dialog--mask-fade-slow"
+        hidden=""
+        role="dialog"
+      >
         <div
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="fullscreen-dialog fullscreen-dialog--mask-fade-slow"
-          hidden=""
-          role="dialog"
+          class="fullscreen-dialog__window fullscreen-dialog__window fullscreen-dialog__window--slide"
         >
           <div
-            class="fullscreen-dialog__window fullscreen-dialog__window fullscreen-dialog__window--slide"
+            class="fullscreen-dialog__header"
           >
-            <div
-              class="fullscreen-dialog__header"
+            <button
+              class="icon-btn fullscreen-dialog__close"
+              type="button"
             >
-              <button
-                class="icon-btn fullscreen-dialog__close"
-                type="button"
+              <svg
+                aria-hidden="true"
+                class="icon icon--close"
+                focusable="false"
+                height="24px"
+                width="24px"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  class="icon icon--close"
-                  focusable="false"
-                  height="24px"
-                  width="24px"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <use
-                    xlink:href="#icon-close"
-                  />
-                </svg>
-              </button>
-              <h2
-                id="dialog-title-abc123"
-              >
-                Heading
-              </h2>
-            </div>
-            <div
-              class="fullscreen-dialog__main"
+                <use
+                  xlink:href="#icon-close"
+                />
+              </svg>
+            </button>
+            <h2
+              id="dialog-title-abc123"
             >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                <a
-                  href="http://www.ebay.com"
-                >
-                  www.ebay.com
-                </a>
-              </p>
-            </div>
+              Heading
+            </h2>
+          </div>
+          <div
+            class="fullscreen-dialog__main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              <a
+                href="http://www.ebay.com"
+              >
+                www.ebay.com
+              </a>
+            </p>
           </div>
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;

--- a/src/ebay-lightbox-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-lightbox-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -11,24 +11,23 @@ exports[`Storyshots ebay-lightbox-dialog Always Opened 1`] = `
       Some outside content...
     </p>
     <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
       aria-hidden="false"
-      data-focus-lock-disabled="false"
     >
       <div
         aria-hidden="false"
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="lightbox-dialog lightbox-dialog--mask-fade"
+        role="dialog"
       >
         <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
+        <div
           aria-hidden="false"
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="lightbox-dialog lightbox-dialog--mask-fade"
-          role="dialog"
+          class="lightbox-dialog__window lightbox-dialog__window--fade keyboard-trap--active"
         >
           <div
             aria-hidden="true"
@@ -36,60 +35,45 @@ exports[`Storyshots ebay-lightbox-dialog Always Opened 1`] = `
             tabindex="0"
           />
           <div
-            aria-hidden="false"
-            class="lightbox-dialog__window lightbox-dialog__window--fade keyboard-trap--active"
+            class="lightbox-dialog__header"
           >
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
-            <div
-              class="lightbox-dialog__header"
+            <h2
+              id="dialog-title-abc123"
             >
-              <h2
-                id="dialog-title-abc123"
-              >
-                Heading
-              </h2>
-              <button
-                aria-label="Close Dialog"
-                class="icon-btn lightbox-dialog__close"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="icon icon--close"
-                  focusable="false"
-                  height="24px"
-                  width="24px"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <use
-                    xlink:href="#icon-close"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="lightbox-dialog__main"
+              Heading
+            </h2>
+            <button
+              aria-label="Close Dialog"
+              class="icon-btn lightbox-dialog__close"
+              type="button"
             >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                <a
-                  href="http://www.ebay.com"
-                >
-                  www.ebay.com
-                </a>
-              </p>
-            </div>
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
+              <svg
+                aria-hidden="true"
+                class="icon icon--close"
+                focusable="false"
+                height="24px"
+                width="24px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="#icon-close"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="lightbox-dialog__main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              <a
+                href="http://www.ebay.com"
+              >
+                www.ebay.com
+              </a>
+            </p>
           </div>
           <div
             aria-hidden="true"
@@ -97,14 +81,13 @@ exports[`Storyshots ebay-lightbox-dialog Always Opened 1`] = `
             tabindex="0"
           />
         </div>
+        <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;
@@ -147,24 +130,23 @@ exports[`Storyshots ebay-lightbox-dialog Mini Dialog 1`] = `
       Some outside content...
     </p>
     <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
       aria-hidden="false"
-      data-focus-lock-disabled="false"
     >
       <div
         aria-hidden="false"
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="lightbox-dialog lightbox-dialog--mask-fade"
+        role="dialog"
       >
         <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
+        <div
           aria-hidden="false"
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="lightbox-dialog lightbox-dialog--mask-fade"
-          role="dialog"
+          class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini keyboard-trap--active"
         >
           <div
             aria-hidden="true"
@@ -172,51 +154,36 @@ exports[`Storyshots ebay-lightbox-dialog Mini Dialog 1`] = `
             tabindex="0"
           />
           <div
-            aria-hidden="false"
-            class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini keyboard-trap--active"
+            class="lightbox-dialog__header"
           >
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
+            <h2
+              id="dialog-title-abc123"
             />
-            <div
-              class="lightbox-dialog__header"
+            <button
+              aria-label="Close Dialog"
+              class="icon-btn lightbox-dialog__close"
+              type="button"
             >
-              <h2
-                id="dialog-title-abc123"
-              />
-              <button
-                aria-label="Close Dialog"
-                class="icon-btn lightbox-dialog__close"
-                type="button"
+              <svg
+                aria-hidden="true"
+                class="icon icon--close"
+                focusable="false"
+                height="24px"
+                width="24px"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  class="icon icon--close"
-                  focusable="false"
-                  height="24px"
-                  width="24px"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <use
-                    xlink:href="#icon-close"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="lightbox-dialog__main"
-            >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-              </p>
-            </div>
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
+                <use
+                  xlink:href="#icon-close"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="lightbox-dialog__main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
           </div>
           <div
             aria-hidden="true"
@@ -224,14 +191,13 @@ exports[`Storyshots ebay-lightbox-dialog Mini Dialog 1`] = `
             tabindex="0"
           />
         </div>
+        <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;
@@ -247,24 +213,23 @@ exports[`Storyshots ebay-lightbox-dialog Scrolling Content 1`] = `
       Some outside content...
     </p>
     <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
       aria-hidden="false"
-      data-focus-lock-disabled="false"
     >
       <div
         aria-hidden="false"
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="lightbox-dialog lightbox-dialog--mask-fade"
+        role="dialog"
       >
         <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
+        <div
           aria-hidden="false"
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="lightbox-dialog lightbox-dialog--mask-fade"
-          role="dialog"
+          class="lightbox-dialog__window lightbox-dialog__window--fade keyboard-trap--active"
         >
           <div
             aria-hidden="true"
@@ -272,87 +237,72 @@ exports[`Storyshots ebay-lightbox-dialog Scrolling Content 1`] = `
             tabindex="0"
           />
           <div
-            aria-hidden="false"
-            class="lightbox-dialog__window lightbox-dialog__window--fade keyboard-trap--active"
+            class="lightbox-dialog__header"
           >
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
-            <div
-              class="lightbox-dialog__header"
+            <h2
+              id="dialog-title-abc123"
             >
-              <h2
-                id="dialog-title-abc123"
-              >
-                Heading
-              </h2>
-              <button
-                aria-label="Close Dialog"
-                class="icon-btn lightbox-dialog__close"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="icon icon--close"
-                  focusable="false"
-                  height="24px"
-                  width="24px"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <use
-                    xlink:href="#icon-close"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="lightbox-dialog__main"
+              Heading
+            </h2>
+            <button
+              aria-label="Close Dialog"
+              class="icon-btn lightbox-dialog__close"
+              type="button"
             >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                <a
-                  href="http://www.ebay.com"
-                >
-                  www.ebay.com
-                </a>
-              </p>
-            </div>
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
+              <svg
+                aria-hidden="true"
+                class="icon icon--close"
+                focusable="false"
+                height="24px"
+                width="24px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="#icon-close"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="lightbox-dialog__main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              <a
+                href="http://www.ebay.com"
+              >
+                www.ebay.com
+              </a>
+            </p>
           </div>
           <div
             aria-hidden="true"
@@ -360,14 +310,13 @@ exports[`Storyshots ebay-lightbox-dialog Scrolling Content 1`] = `
             tabindex="0"
           />
         </div>
+        <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;
@@ -383,89 +332,75 @@ exports[`Storyshots ebay-lightbox-dialog With Animation 1`] = `
     <p>
       Some outside content...
     </p>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
-      data-focus-lock-disabled="false"
-    >
-      <div>
+    <div>
+      <div
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="lightbox-dialog lightbox-dialog--mask-fade"
+        hidden=""
+        role="dialog"
+      >
         <div
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="lightbox-dialog lightbox-dialog--mask-fade"
-          hidden=""
-          role="dialog"
+          class="lightbox-dialog__window lightbox-dialog__window--fade"
         >
           <div
-            class="lightbox-dialog__window lightbox-dialog__window--fade"
+            class="lightbox-dialog__header"
           >
-            <div
-              class="lightbox-dialog__header"
+            <h2
+              id="dialog-title-abc123"
             >
-              <h2
-                id="dialog-title-abc123"
-              >
-                Heading
-              </h2>
-              <button
-                aria-label="Close Dialog"
-                class="icon-btn lightbox-dialog__close"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="icon icon--close"
-                  focusable="false"
-                  height="24px"
-                  width="24px"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <use
-                    xlink:href="#icon-close"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="lightbox-dialog__main"
+              Heading
+            </h2>
+            <button
+              aria-label="Close Dialog"
+              class="icon-btn lightbox-dialog__close"
+              type="button"
             >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                <a
-                  href="http://www.ebay.com"
-                >
-                  www.ebay.com
-                </a>
-              </p>
-            </div>
-            <div
-              class="lightbox-dialog__footer"
+              <svg
+                aria-hidden="true"
+                class="icon icon--close"
+                focusable="false"
+                height="24px"
+                width="24px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="#icon-close"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="lightbox-dialog__main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              <a
+                href="http://www.ebay.com"
+              >
+                www.ebay.com
+              </a>
+            </p>
+          </div>
+          <div
+            class="lightbox-dialog__footer"
+          >
+            <button
+              class="btn btn--primary"
             >
-              <button
-                class="btn btn--primary"
-              >
-                OK
-              </button>
-              <button
-                class="btn btn--secondary"
-              >
-                Cancel
-              </button>
-            </div>
+              OK
+            </button>
+            <button
+              class="btn btn--secondary"
+            >
+              Cancel
+            </button>
           </div>
         </div>
       </div>
     </div>
-    <div
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;

--- a/src/ebay-panel-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-panel-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -11,25 +11,24 @@ exports[`Storyshots ebay-panel-dialog Always Opened 1`] = `
       Some outside content...
     </p>
     <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
       aria-hidden="false"
-      data-focus-lock-disabled="false"
     >
       <div
         aria-hidden="false"
+        aria-label="Infotip"
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="panel-dialog"
+        role="dialog"
       >
         <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
+        <div
           aria-hidden="false"
-          aria-label="Infotip"
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="panel-dialog"
-          role="dialog"
+          class="panel-dialog__window panel-dialog__window--slide keyboard-trap--active"
         >
           <div
             aria-hidden="true"
@@ -37,59 +36,44 @@ exports[`Storyshots ebay-panel-dialog Always Opened 1`] = `
             tabindex="0"
           />
           <div
-            aria-hidden="false"
-            class="panel-dialog__window panel-dialog__window--slide keyboard-trap--active"
+            class="panel-dialog__header"
           >
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
-            <div
-              class="panel-dialog__header"
+            <h2
+              id="dialog-title-abc123"
             >
-              <h2
-                id="dialog-title-abc123"
-              >
-                Heading
-              </h2>
-              <button
-                class="icon-btn panel-dialog__close"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="icon icon--close"
-                  focusable="false"
-                  height="24px"
-                  width="24px"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <use
-                    xlink:href="#icon-close"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="panel-dialog__main"
+              Heading
+            </h2>
+            <button
+              class="icon-btn panel-dialog__close"
+              type="button"
             >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-              <p>
-                <a
-                  href="http://www.ebay.com"
-                >
-                  www.ebay.com
-                </a>
-              </p>
-            </div>
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
+              <svg
+                aria-hidden="true"
+                class="icon icon--close"
+                focusable="false"
+                height="24px"
+                width="24px"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <use
+                  xlink:href="#icon-close"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="panel-dialog__main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
+            <p>
+              <a
+                href="http://www.ebay.com"
+              >
+                www.ebay.com
+              </a>
+            </p>
           </div>
           <div
             aria-hidden="true"
@@ -97,14 +81,13 @@ exports[`Storyshots ebay-panel-dialog Always Opened 1`] = `
             tabindex="0"
           />
         </div>
+        <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;
@@ -120,25 +103,24 @@ exports[`Storyshots ebay-panel-dialog Custom Close Button 1`] = `
       Some outside content...
     </p>
     <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
       aria-hidden="false"
-      data-focus-lock-disabled="false"
     >
       <div
         aria-hidden="false"
+        aria-label="Infotip"
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="panel-dialog"
+        role="dialog"
       >
         <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
+        <div
           aria-hidden="false"
-          aria-label="Infotip"
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="panel-dialog"
-          role="dialog"
+          class="panel-dialog__window panel-dialog__window--slide keyboard-trap--active"
         >
           <div
             aria-hidden="true"
@@ -146,41 +128,26 @@ exports[`Storyshots ebay-panel-dialog Custom Close Button 1`] = `
             tabindex="0"
           />
           <div
-            aria-hidden="false"
-            class="panel-dialog__window panel-dialog__window--slide keyboard-trap--active"
+            class="panel-dialog__header"
           >
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
-            <div
-              class="panel-dialog__header"
+            <h2
+              id="dialog-title-abc123"
             >
-              <h2
-                id="dialog-title-abc123"
-              >
-                Heading
-              </h2>
-              <button
-                class="icon-btn panel-dialog__close"
-                type="button"
-              >
-                X
-              </button>
-            </div>
-            <div
-              class="panel-dialog__main"
+              Heading
+            </h2>
+            <button
+              class="icon-btn panel-dialog__close"
+              type="button"
             >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-            </div>
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
+              X
+            </button>
+          </div>
+          <div
+            class="panel-dialog__main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
           </div>
           <div
             aria-hidden="true"
@@ -188,14 +155,13 @@ exports[`Storyshots ebay-panel-dialog Custom Close Button 1`] = `
             tabindex="0"
           />
         </div>
+        <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;
@@ -226,25 +192,24 @@ exports[`Storyshots ebay-panel-dialog From Right 1`] = `
       Some outside content...
     </p>
     <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
-    <div
       aria-hidden="false"
-      data-focus-lock-disabled="false"
     >
       <div
         aria-hidden="false"
+        aria-label="Infotip"
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="panel-dialog"
+        role="dialog"
       >
         <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
+        <div
           aria-hidden="false"
-          aria-label="Infotip"
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="panel-dialog"
-          role="dialog"
+          class="panel-dialog__window panel-dialog__window--slide panel-dialog__window--end keyboard-trap--active"
         >
           <div
             aria-hidden="true"
@@ -252,50 +217,35 @@ exports[`Storyshots ebay-panel-dialog From Right 1`] = `
             tabindex="0"
           />
           <div
-            aria-hidden="false"
-            class="panel-dialog__window panel-dialog__window--slide panel-dialog__window--end keyboard-trap--active"
+            class="panel-dialog__header"
           >
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
+            <h2
+              id="dialog-title-abc123"
             />
-            <div
-              class="panel-dialog__header"
+            <button
+              class="icon-btn panel-dialog__close"
+              type="button"
             >
-              <h2
-                id="dialog-title-abc123"
-              />
-              <button
-                class="icon-btn panel-dialog__close"
-                type="button"
+              <svg
+                aria-hidden="true"
+                class="icon icon--close"
+                focusable="false"
+                height="24px"
+                width="24px"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <svg
-                  aria-hidden="true"
-                  class="icon icon--close"
-                  focusable="false"
-                  height="24px"
-                  width="24px"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <use
-                    xlink:href="#icon-close"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="panel-dialog__main"
-            >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-              </p>
-            </div>
-            <div
-              aria-hidden="true"
-              class="keyboard-trap-boundary"
-              tabindex="0"
-            />
+                <use
+                  xlink:href="#icon-close"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="panel-dialog__main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            </p>
           </div>
           <div
             aria-hidden="true"
@@ -303,14 +253,13 @@ exports[`Storyshots ebay-panel-dialog From Right 1`] = `
             tabindex="0"
           />
         </div>
+        <div
+          aria-hidden="true"
+          class="keyboard-trap-boundary"
+          tabindex="0"
+        />
       </div>
     </div>
-    <div
-      aria-hidden="true"
-      data-focus-guard="true"
-      style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-      tabindex="0"
-    />
   </div>
 </DocumentFragment>
 `;
@@ -325,75 +274,61 @@ exports[`Storyshots ebay-panel-dialog With Animation 1`] = `
   <p>
     Some outside content...
   </p>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
-  <div
-    data-focus-lock-disabled="false"
-  >
-    <div>
+  <div>
+    <div
+      aria-label="Infotip"
+      aria-labelledby="dialog-title-abc123"
+      arial-modal="true"
+      class="panel-dialog panel-dialog--mask-fade-slow"
+      hidden=""
+      role="dialog"
+    >
       <div
-        aria-label="Infotip"
-        aria-labelledby="dialog-title-abc123"
-        arial-modal="true"
-        class="panel-dialog panel-dialog--mask-fade-slow"
-        hidden=""
-        role="dialog"
+        class="panel-dialog__window panel-dialog__window--slide"
       >
         <div
-          class="panel-dialog__window panel-dialog__window--slide"
+          class="panel-dialog__header"
         >
-          <div
-            class="panel-dialog__header"
+          <h2
+            id="dialog-title-abc123"
           >
-            <h2
-              id="dialog-title-abc123"
-            >
-              Heading
-            </h2>
-            <button
-              class="icon-btn panel-dialog__close"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="icon icon--close"
-                focusable="false"
-                height="24px"
-                width="24px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <use
-                  xlink:href="#icon-close"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="panel-dialog__main"
+            Heading
+          </h2>
+          <button
+            class="icon-btn panel-dialog__close"
+            type="button"
           >
-            <p>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-            </p>
-            <p>
-              <a
-                href="http://www.ebay.com"
-              >
-                www.ebay.com
-              </a>
-            </p>
-          </div>
+            <svg
+              aria-hidden="true"
+              class="icon icon--close"
+              focusable="false"
+              height="24px"
+              width="24px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <use
+                xlink:href="#icon-close"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          class="panel-dialog__main"
+        >
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+          <p>
+            <a
+              href="http://www.ebay.com"
+            >
+              www.ebay.com
+            </a>
+          </p>
         </div>
       </div>
     </div>
   </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
 </DocumentFragment>
 `;
 
@@ -407,74 +342,60 @@ exports[`Storyshots ebay-panel-dialog With Animation From Right 1`] = `
   <p>
     Some outside content...
   </p>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
-  <div
-    data-focus-lock-disabled="false"
-  >
-    <div>
+  <div>
+    <div
+      aria-label="Infotip"
+      aria-labelledby="dialog-title-abc123"
+      arial-modal="true"
+      class="panel-dialog panel-dialog--mask-fade-slow"
+      hidden=""
+      role="dialog"
+    >
       <div
-        aria-label="Infotip"
-        aria-labelledby="dialog-title-abc123"
-        arial-modal="true"
-        class="panel-dialog panel-dialog--mask-fade-slow"
-        hidden=""
-        role="dialog"
+        class="panel-dialog__window panel-dialog__window--slide panel-dialog__window--end"
       >
         <div
-          class="panel-dialog__window panel-dialog__window--slide panel-dialog__window--end"
+          class="panel-dialog__header"
         >
-          <div
-            class="panel-dialog__header"
+          <h2
+            id="dialog-title-abc123"
           >
-            <h2
-              id="dialog-title-abc123"
-            >
-              Heading
-            </h2>
-            <button
-              class="icon-btn panel-dialog__close"
-              type="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="icon icon--close"
-                focusable="false"
-                height="24px"
-                width="24px"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <use
-                  xlink:href="#icon-close"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="panel-dialog__main"
+            Heading
+          </h2>
+          <button
+            class="icon-btn panel-dialog__close"
+            type="button"
           >
-            <p>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-            </p>
-            <p>
-              <a
-                href="http://www.ebay.com"
-              >
-                www.ebay.com
-              </a>
-            </p>
-          </div>
+            <svg
+              aria-hidden="true"
+              class="icon icon--close"
+              focusable="false"
+              height="24px"
+              width="24px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <use
+                xlink:href="#icon-close"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          class="panel-dialog__main"
+        >
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+          <p>
+            <a
+              href="http://www.ebay.com"
+            >
+              www.ebay.com
+            </a>
+          </p>
         </div>
       </div>
     </div>
   </div>
-  <div
-    data-focus-guard="true"
-    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
-    tabindex="0"
-  />
 </DocumentFragment>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,7 +1074,7 @@
     core-js-pure "^3.20.2"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.3.tgz#c7b654b57f6f63cf7f8b418ac9ca04408c4579f4"
   integrity sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==
@@ -6464,13 +6464,6 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-focus-lock@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.11.2.tgz#aeef3caf1cea757797ac8afdebaec8fd9ab243ed"
-  integrity sha512-pZ2bO++NWLHhiKkgP1bEXHhR1/OjVcSvlCJ98aNJDFeb7H5OOQaO+SKOZle6041O9rv2tmbrO4JzClAvDUHf0g==
-  dependencies:
-    tslib "^2.0.3"
-
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -10658,13 +10651,6 @@ raw-loader@^4.0.2:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-react-clientside-effect@^1.2.6:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz#29f9b14e944a376b03fb650eed2a754dd128ea3a"
-  integrity sha512-XGGGRQAKY+q25Lz9a/4EPqom7WRjz3z9R2k4jhVKA/puQFH/5Nt27vFZYql4m4NVNdUvX8PS3O7r/Zzm7cjUlg==
-  dependencies:
-    "@babel/runtime" "^7.12.13"
-
 react-colorful@^5.1.2:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.5.1.tgz#29d9c4e496f2ca784dd2bb5053a3a4340cfaf784"
@@ -10730,18 +10716,6 @@ react-error-boundary@^3.1.0:
   integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
   dependencies:
     "@babel/runtime" "^7.12.5"
-
-react-focus-lock@^2.9.1:
-  version "2.9.1"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.9.1.tgz#094cfc19b4f334122c73bb0bff65d77a0c92dd16"
-  integrity sha512-pSWOQrUmiKLkffPO6BpMXN7SNKXMsuOakl652IBuALAu1esk+IcpJyM+ALcYzPTTFz1rD0R54aB9A4HuP5t1Wg==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    focus-lock "^0.11.2"
-    prop-types "^15.6.2"
-    react-clientside-effect "^1.2.6"
-    use-callback-ref "^1.3.0"
-    use-sidecar "^1.1.2"
 
 react-input-autosize@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Remove react focus lock which was removed on [a PR to fix dialog animation issue](https://github.corp.ebay.com/React/ebayui-core-react/pull/453) but accidentally [brought back on the PR to fix toast dialog accessibility issue](https://github.corp.ebay.com/React/ebayui-core-react/pull/391/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R63).

- The dialog focus trap should be handle by makeup-keyboard-trap
- This PR potentially could fix the focus issue of a dialog with a text input (the focus stays inside the input text even if user clicks on the dialog area).