### PR TITLE
FIX: ebay-icon generates incorrect SVG width & height values

### DIFF
--- a/src/ebay-checkbox/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-checkbox/__tests__/__snapshots__/index.spec.tsx.snap
@@ -121,8 +121,8 @@ exports[`Storyshots ebay-checkbox Default checkbox-button 1`] = `
           aria-hidden="true"
           class="checkbox__checked icon icon--checkbox-checked-large"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="64px"
+          width="64px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -133,8 +133,8 @@ exports[`Storyshots ebay-checkbox Default checkbox-button 1`] = `
           aria-hidden="true"
           class="checkbox__unchecked icon icon--checkbox-unchecked-large"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="64px"
+          width="64px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -224,8 +224,8 @@ exports[`Storyshots ebay-checkbox Disabled checkbox-button 1`] = `
           aria-hidden="true"
           class="checkbox__checked icon icon--checkbox-checked-large"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="64px"
+          width="64px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -236,8 +236,8 @@ exports[`Storyshots ebay-checkbox Disabled checkbox-button 1`] = `
           aria-hidden="true"
           class="checkbox__unchecked icon icon--checkbox-unchecked-large"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="64px"
+          width="64px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -490,8 +490,8 @@ exports[`Storyshots ebay-checkbox Selected checkbox-button 1`] = `
           aria-hidden="true"
           class="checkbox__checked icon icon--checkbox-checked-large"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="64px"
+          width="64px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -502,8 +502,8 @@ exports[`Storyshots ebay-checkbox Selected checkbox-button 1`] = `
           aria-hidden="true"
           class="checkbox__unchecked icon icon--checkbox-unchecked-large"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="64px"
+          width="64px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use

--- a/src/ebay-icon-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-icon-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -130,8 +130,8 @@ exports[`Storyshots ebay-icon-button With Badges 1`] = `
         aria-hidden="true"
         class="icon icon--chat-large"
         focusable="false"
-        height="24px"
-        width="24px"
+        height="64px"
+        width="64px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use

--- a/src/ebay-icon/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-icon/__tests__/__snapshots__/index.spec.tsx.snap
@@ -32,8 +32,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--add-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -70,8 +70,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--archive-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -127,8 +127,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--arrow-left-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -165,8 +165,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--arrow-move-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -222,8 +222,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--arrow-right-extra-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -260,8 +260,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--arrow-right-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -317,8 +317,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--attention-filled-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -336,8 +336,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--attention-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -488,8 +488,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--bank-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -526,8 +526,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--bids-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -583,8 +583,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--calendar-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -602,8 +602,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--calendar-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -640,8 +640,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--camera-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -716,8 +716,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--cart-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -735,8 +735,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--cart-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -792,8 +792,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--certified-recycle-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -811,8 +811,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--chat-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -849,8 +849,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--checkbox-checked-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -887,8 +887,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--checkbox-mixed-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -925,8 +925,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--checkbox-square-checked-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -963,8 +963,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--checkbox-square-unchecked-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1001,8 +1001,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--checkbox-unchecked-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1058,8 +1058,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--chevron-down-extra-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1077,8 +1077,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--chevron-down-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1115,8 +1115,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--chevron-left-extra-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1134,8 +1134,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--chevron-left-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1172,8 +1172,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--chevron-right-extra-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1191,8 +1191,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--chevron-right-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1248,8 +1248,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--chevron-up-extra-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1267,8 +1267,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--chevron-up-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1324,8 +1324,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--clear-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1362,8 +1362,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--clock-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1400,8 +1400,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--close-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1457,8 +1457,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--confirmation-filled-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1476,8 +1476,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--confirmation-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1514,8 +1514,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--credit-card-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1533,8 +1533,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--credit-card-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1590,8 +1590,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--customize-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1647,8 +1647,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--delete-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1685,8 +1685,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--download-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1742,8 +1742,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--edit-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1837,8 +1837,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--event-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1875,8 +1875,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--fast-n-free-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1932,8 +1932,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--filter-gallery-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1970,8 +1970,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--filter-list-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2027,8 +2027,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--filter-single-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2046,8 +2046,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--filter-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2065,8 +2065,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--fingerprint-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2103,8 +2103,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--flag-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2141,8 +2141,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--folder-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2179,8 +2179,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--following-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2217,8 +2217,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--gift-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2236,8 +2236,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--gift-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2274,8 +2274,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--help-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2312,8 +2312,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--hide-secret-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2388,8 +2388,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--inbox-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2445,8 +2445,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--information-filled-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2464,8 +2464,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2559,8 +2559,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--lightbulb-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2597,8 +2597,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--live-eye-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2635,8 +2635,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--location-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2673,8 +2673,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--locked-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2711,8 +2711,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--mail-move-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2749,8 +2749,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--mail-open-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2787,8 +2787,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--mail-unread-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2863,8 +2863,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--messages-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2882,8 +2882,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--messages-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2920,8 +2920,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--mic-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -2996,8 +2996,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--money-back-guarantee-us-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3053,8 +3053,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--overflow-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3167,8 +3167,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--pause-filled-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3186,8 +3186,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--pause-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3205,8 +3205,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--pause-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3357,8 +3357,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--photo-gallery-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3395,8 +3395,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--photo-image-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3528,8 +3528,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--play-filled-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3547,8 +3547,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--play-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3566,8 +3566,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--play-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3870,8 +3870,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--purchases-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3908,8 +3908,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--radio-checked-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3946,8 +3946,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--radio-unchecked-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -3984,8 +3984,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--red-laser-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4060,8 +4060,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--reply-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4098,8 +4098,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--report-flag-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4136,8 +4136,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--return-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4212,8 +4212,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--save-selected-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4231,8 +4231,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--save-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4269,8 +4269,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--scan-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4345,8 +4345,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--search-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4364,8 +4364,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--search-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4478,8 +4478,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--settings-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4516,8 +4516,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--share-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4573,8 +4573,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--show-secret-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4858,8 +4858,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--sort-down-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4877,8 +4877,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--sort-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4896,8 +4896,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--sort-up-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4934,8 +4934,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--spinner-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -4991,8 +4991,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--star-empty-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5029,8 +5029,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--star-full-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5067,8 +5067,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--star-half-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5105,8 +5105,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--star-undefined-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5219,8 +5219,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--store-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5390,8 +5390,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--text-messaging-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5447,8 +5447,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--thumbs-down-selected-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5466,8 +5466,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--thumbs-down-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5523,8 +5523,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--thumbs-up-selected-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5542,8 +5542,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--thumbs-up-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5580,8 +5580,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--tick-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5637,8 +5637,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--truck-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5694,8 +5694,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--unlocked-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5751,8 +5751,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--vault-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5827,8 +5827,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--visa-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5846,8 +5846,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--visa-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -5903,8 +5903,8 @@ exports[`Storyshots ebay-icon all icons 1`] = `
             aria-hidden="true"
             class="icon icon--watch-large"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="64px"
+            width="64px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use

--- a/src/ebay-icon/icon.tsx
+++ b/src/ebay-icon/icon.tsx
@@ -4,8 +4,10 @@ import { withForwardRef } from '../common/component-utils'
 import { randomId } from '../common/random-id'
 import { Icon } from './types'
 
-const SMALL_ICON_SIZE = 16
-const LARGE_ICON_SIZE = 64
+const iconPixelSizes: Record<string, number> = {
+    small: 16,
+    large: 64
+}
 const DEFAULT_ICON_SIZE = 24
 
 export type A11yVariant = 'label';
@@ -36,18 +38,18 @@ const EbayIcon: FC<EbayIconProps> = ({
         setRandomId(randomId())
     }, [])
 
-    const noTitle = a11yVariant === 'label'
+    const withAriaLabel = a11yVariant === 'label'
     const a11yTextId = a11yText && `icon-title-${rId}`
     const a11yProps = a11yText ? {
-        'aria-labelledby': noTitle ? undefined : a11yTextId,
-        'aria-label': noTitle ? a11yText : undefined,
+        'aria-labelledby': withAriaLabel ? undefined : a11yTextId,
+        'aria-label': withAriaLabel ? a11yText : undefined,
         role: 'img'
     } : {
         'aria-hidden': true
     }
-    const iconSize = `${getIconSize(name)}px`
     const prefixSvg = type === 'icon' ? 'icon-' : ''
     const kebabName = kebabCased(name)
+    const iconSize = `${getIconPixelSize(kebabName)}px`
     const className = classNames(extraClass,
         { [getIconClass(type, kebabName)]: !noSkinClasses }
     )
@@ -63,23 +65,21 @@ const EbayIcon: FC<EbayIconProps> = ({
             ref={forwardedRef}
             {...a11yProps}
         >
-            {a11yText && !noTitle && <title id={a11yTextId}>{a11yText}</title>}
+            {a11yText && !withAriaLabel && <title id={a11yTextId}>{a11yText}</title>}
             <use xlinkHref={`#${prefixSvg}${kebabName}`} />
         </svg>
     )
 }
 
-function getIconSize(iconName) {
+function getIconPixelSize(iconName: string) {
     const sizeCandidate = iconName.split('-').slice(-1)[0]
-    return {
-        small: SMALL_ICON_SIZE,
-        large: LARGE_ICON_SIZE
-    }[sizeCandidate] || DEFAULT_ICON_SIZE
+    return iconPixelSizes[sizeCandidate] || DEFAULT_ICON_SIZE
 }
 
-function kebabCased(str) {
+function kebabCased(str: string) {
     return str.replace(/([A-Z])/g, (s, c) => `-${c.toLowerCase()}`)
 }
+
 function getIconClass(type, name) {
     if (type === 'icon') {
         return `icon icon--${name}`
@@ -87,4 +87,5 @@ function getIconClass(type, name) {
     const dashedName = name.replace(type, `${type}-`)
     return `${type} ${dashedName}`
 }
+
 export default withForwardRef(EbayIcon)

--- a/src/ebay-infotip/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-infotip/__tests__/__snapshots__/index.spec.tsx.snap
@@ -22,8 +22,8 @@ exports[`Storyshots ebay-infotip Custom button content (With render prop) 1`] = 
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -186,8 +186,8 @@ exports[`Storyshots ebay-infotip Default 1`] = `
           aria-hidden="true"
           class="icon icon--information-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -266,8 +266,8 @@ exports[`Storyshots ebay-infotip Disabled 1`] = `
           aria-hidden="true"
           class="icon icon--information-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -345,8 +345,8 @@ exports[`Storyshots ebay-infotip Expanded by default 1`] = `
           aria-hidden="true"
           class="icon icon--information-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -429,8 +429,8 @@ exports[`Storyshots ebay-infotip In paragraph 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -510,8 +510,8 @@ exports[`Storyshots ebay-infotip Modal 1`] = `
           aria-hidden="true"
           class="icon icon--information-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -546,8 +546,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -621,8 +621,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -696,8 +696,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -771,8 +771,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -846,8 +846,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -921,8 +921,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -996,8 +996,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1071,8 +1071,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1146,8 +1146,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1221,8 +1221,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1296,8 +1296,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1371,8 +1371,8 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
             aria-hidden="true"
             class="icon icon--information-small"
             focusable="false"
-            height="24px"
-            width="24px"
+            height="16px"
+            width="16px"
             xmlns="http://www.w3.org/2000/svg"
           >
             <use
@@ -1451,8 +1451,8 @@ exports[`Storyshots ebay-infotip Pointer with custom location 1`] = `
           aria-hidden="true"
           class="icon icon--information-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use

--- a/src/ebay-menu/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-menu/__tests__/__snapshots__/index.spec.tsx.snap
@@ -24,8 +24,8 @@ exports[`Storyshots ebay-menu Checkbox 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -47,8 +47,8 @@ exports[`Storyshots ebay-menu Checkbox 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -71,8 +71,8 @@ exports[`Storyshots ebay-menu Checkbox 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -108,8 +108,8 @@ exports[`Storyshots ebay-menu Default 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -131,8 +131,8 @@ exports[`Storyshots ebay-menu Default 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -154,8 +154,8 @@ exports[`Storyshots ebay-menu Default 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -192,8 +192,8 @@ exports[`Storyshots ebay-menu Radio 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -216,8 +216,8 @@ exports[`Storyshots ebay-menu Radio 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -240,8 +240,8 @@ exports[`Storyshots ebay-menu Radio 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -284,8 +284,8 @@ exports[`Storyshots ebay-menu With Badges 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -314,8 +314,8 @@ exports[`Storyshots ebay-menu With Badges 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -337,8 +337,8 @@ exports[`Storyshots ebay-menu With Badges 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -374,8 +374,8 @@ exports[`Storyshots ebay-menu With Disabled Item 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -398,8 +398,8 @@ exports[`Storyshots ebay-menu With Disabled Item 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -421,8 +421,8 @@ exports[`Storyshots ebay-menu With Disabled Item 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -471,8 +471,8 @@ exports[`Storyshots ebay-menu With Icons 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -508,8 +508,8 @@ exports[`Storyshots ebay-menu With Icons 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -545,8 +545,8 @@ exports[`Storyshots ebay-menu With Icons 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -582,8 +582,8 @@ exports[`Storyshots ebay-menu With Separator 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -605,8 +605,8 @@ exports[`Storyshots ebay-menu With Separator 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -633,8 +633,8 @@ exports[`Storyshots ebay-menu With Separator 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -656,8 +656,8 @@ exports[`Storyshots ebay-menu With Separator 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -679,8 +679,8 @@ exports[`Storyshots ebay-menu With Separator 1`] = `
           aria-hidden="true"
           class="icon icon--tick-small"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="16px"
+          width="16px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use

--- a/src/ebay-radio/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-radio/__tests__/__snapshots__/index.spec.tsx.snap
@@ -69,8 +69,8 @@ exports[`Storyshots ebay-radio Default 1`] = `
           aria-hidden="true"
           class="radio__checked icon icon--radio-checked-large"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="64px"
+          width="64px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -81,8 +81,8 @@ exports[`Storyshots ebay-radio Default 1`] = `
           aria-hidden="true"
           class="radio__unchecked icon icon--radio-unchecked-large"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="64px"
+          width="64px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -493,8 +493,8 @@ exports[`Storyshots ebay-radio Using custom label html 1`] = `
           aria-hidden="true"
           class="radio__checked icon icon--radio-checked-large"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="64px"
+          width="64px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use
@@ -505,8 +505,8 @@ exports[`Storyshots ebay-radio Using custom label html 1`] = `
           aria-hidden="true"
           class="radio__unchecked icon icon--radio-unchecked-large"
           focusable="false"
-          height="24px"
-          width="24px"
+          height="64px"
+          width="64px"
           xmlns="http://www.w3.org/2000/svg"
         >
           <use


### PR DESCRIPTION
## Problems

The EbayIcon does not properly render SVG width and height attributes. It should generate the default SVG width & height based on icon suffix name (e.g `small`, `large`) but it did not work and always fallback to the default size 24px (see [EbayIcon snapshot](https://github.com/eBay/ebayui-core-react/blob/1.4.2/src/ebay-icon/__tests__/__snapshots__/index.spec.tsx.snap#L31-L38) for an example)

```jsx
<EbayIcon name="addSmall" />

// OUTPUT
<svg
  class="icon icon--add-small"
  height="24px"  // EXPECTED: should be 16px
  width="24px"  // EXPECTED: should be 16px
  // ...
/>

<EbayIcon name="bankLarge" />

// OUTPUT
<svg
  class="icon icon--bank-large"
  height="24px"  // EXPECTED: should be 64px
  width="24px"  // EXPECTED: should be 64px
  // ...
/>
```

## Cause

EbayIcon check the given icon name and get the size suffixes. However, the **it assumes the icon name will be in kebab case** (e.g `add-small`): https://github.com/eBay/ebayui-core-react/blob/473ca596bff327b579f451fe4e8905bd48e4b32e/src/ebay-icon/icon.tsx#L72-L78

We used to use kebab case name for icon name but moved to **pascalCase** at some point (see https://github.com/eBay/ebayui-core-react/blob/1.4.2/src/ebay-icon/types.ts for icon names, which is also used by TypeScript to validate icon name).

## Fix

- Get the right SVG sizes from the pascalCased icon name.
- Minor refactoring.
- Automatically update all snapshots that has EbayIcon since it now render the right SVG width and height values (small=16px and large=64px)