### PR TITLE
MINOR: Update icon on page, section, & inline notice

### DIFF
--- a/src/ebay-inline-notice/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-inline-notice/__tests__/__snapshots__/index.spec.tsx.snap
@@ -10,15 +10,15 @@ exports[`Storyshots ebay-inline-notice Attention message 1`] = `
     >
       <svg
         aria-label="Attention"
-        class="icon icon--attention-filled"
+        class="icon icon--attention-filled-small"
         focusable="false"
-        height="24px"
+        height="16px"
         role="img"
-        width="24px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-attention-filled"
+          xlink:href="#icon-attention-filled-small"
         />
       </svg>
     </span>
@@ -43,15 +43,15 @@ exports[`Storyshots ebay-inline-notice Confirmation message 1`] = `
     >
       <svg
         aria-label="Confirmation"
-        class="icon icon--confirmation-filled"
+        class="icon icon--confirmation-filled-small"
         focusable="false"
-        height="24px"
+        height="16px"
         role="img"
-        width="24px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-confirmation-filled"
+          xlink:href="#icon-confirmation-filled-small"
         />
       </svg>
     </span>
@@ -100,15 +100,15 @@ exports[`Storyshots ebay-inline-notice Information message 1`] = `
     >
       <svg
         aria-label="Information"
-        class="icon icon--information-filled"
+        class="icon icon--information-filled-small"
         focusable="false"
-        height="24px"
+        height="16px"
         role="img"
-        width="24px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-information-filled"
+          xlink:href="#icon-information-filled-small"
         />
       </svg>
     </span>
@@ -138,15 +138,15 @@ exports[`Storyshots ebay-inline-notice Notice toggle 1`] = `
     >
       <svg
         aria-label="Toggle notice"
-        class="icon icon--confirmation-filled"
+        class="icon icon--confirmation-filled-small"
         focusable="false"
-        height="24px"
+        height="16px"
         role="img"
-        width="24px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-confirmation-filled"
+          xlink:href="#icon-confirmation-filled-small"
         />
       </svg>
     </span>

--- a/src/ebay-inline-notice/inline-notice.tsx
+++ b/src/ebay-inline-notice/inline-notice.tsx
@@ -45,7 +45,7 @@ const EbayInlineNotice: FC<Props> = ({
         <div className={classNames(className, `inline-notice ${!isGeneral ? `inline-notice--${status}` : ``}`)}>
             {!isGeneral ? (
                 <span className="inline-notice__header">
-                    <EbayIcon name={`${status}-filled` as Icon} a11yText={ariaLabel} a11yVariant="label" />
+                    <EbayIcon name={`${status}FilledSmall` as Icon} a11yText={ariaLabel} a11yVariant="label" />
                 </span>
             ) : null}
             <NoticeContent

--- a/src/ebay-page-notice/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-page-notice/__tests__/__snapshots__/index.spec.tsx.snap
@@ -13,15 +13,15 @@ exports[`Storyshots ebay-page-notice Attention message 1`] = `
     >
       <svg
         aria-label="Attention"
-        class="icon icon--attention-filled"
+        class="icon icon--attention-filled-small"
         focusable="false"
-        height="24px"
+        height="16px"
         role="img"
-        width="24px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-attention-filled"
+          xlink:href="#icon-attention-filled-small"
         />
       </svg>
     </div>
@@ -71,15 +71,15 @@ exports[`Storyshots ebay-page-notice Confirmation message 1`] = `
     >
       <svg
         aria-label="Success"
-        class="icon icon--confirmation-filled"
+        class="icon icon--confirmation-filled-small"
         focusable="false"
-        height="24px"
+        height="16px"
         role="img"
-        width="24px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-confirmation-filled"
+          xlink:href="#icon-confirmation-filled-small"
         />
       </svg>
     </div>
@@ -116,15 +116,15 @@ exports[`Storyshots ebay-page-notice Information message 1`] = `
     >
       <svg
         aria-label="Information"
-        class="icon icon--information-filled"
+        class="icon icon--information-filled-small"
         focusable="false"
-        height="24px"
+        height="16px"
         role="img"
-        width="24px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-information-filled"
+          xlink:href="#icon-information-filled-small"
         />
       </svg>
     </div>
@@ -161,15 +161,15 @@ exports[`Storyshots ebay-page-notice Message with footer 1`] = `
     >
       <svg
         aria-label="Congratulations"
-        class="icon icon--confirmation-filled"
+        class="icon icon--confirmation-filled-small"
         focusable="false"
-        height="24px"
+        height="16px"
         role="img"
-        width="24px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-confirmation-filled"
+          xlink:href="#icon-confirmation-filled-small"
         />
       </svg>
     </div>

--- a/src/ebay-page-notice/page-notice.tsx
+++ b/src/ebay-page-notice/page-notice.tsx
@@ -1,7 +1,7 @@
 import React, { FC, ReactElement } from 'react'
 import NoticeContent from '../common/notice-utils/notice-content'
 import { EbayNoticeContent } from '../ebay-notice-base/components/ebay-notice-content'
-import EbayIcon from '../ebay-icon/icon'
+import { EbayIcon, Icon } from '../ebay-icon'
 
 type Props = React.HTMLProps<HTMLElement> & {
     status?: 'general' | 'attention' | 'confirmation' | 'information',
@@ -30,7 +30,7 @@ const EbayPageNotice: FC<Props> = ({
             {status !== `general` ? (
                 <div className="page-notice__header" id={`${status}-status`}>
                     <EbayIcon
-                        name={`${status}-filled` as any}
+                        name={`${status}FilledSmall` as Icon}
                         a11yText={ariaLabel}
                         a11yVariant="label"
                     />

--- a/src/ebay-section-notice/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-section-notice/__tests__/__snapshots__/index.spec.tsx.snap
@@ -14,14 +14,14 @@ exports[`Storyshots ebay-section-notice Attention message 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="icon icon--attention-filled"
+        class="icon icon--attention-filled-small"
         focusable="false"
-        height="24px"
-        width="24px"
+        height="16px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-attention-filled"
+          xlink:href="#icon-attention-filled-small"
         />
       </svg>
     </div>
@@ -72,14 +72,14 @@ exports[`Storyshots ebay-section-notice Confirmation message 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="icon icon--confirmation-filled"
+        class="icon icon--confirmation-filled-small"
         focusable="false"
-        height="24px"
-        width="24px"
+        height="16px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-confirmation-filled"
+          xlink:href="#icon-confirmation-filled-small"
         />
       </svg>
     </div>
@@ -179,14 +179,14 @@ exports[`Storyshots ebay-section-notice Information message 1`] = `
     >
       <svg
         aria-hidden="true"
-        class="icon icon--information-filled"
+        class="icon icon--information-filled-small"
         focusable="false"
-        height="24px"
-        width="24px"
+        height="16px"
+        width="16px"
         xmlns="http://www.w3.org/2000/svg"
       >
         <use
-          xlink:href="#icon-information-filled"
+          xlink:href="#icon-information-filled-small"
         />
       </svg>
     </div>

--- a/src/ebay-section-notice/section-notice.tsx
+++ b/src/ebay-section-notice/section-notice.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactElement } from 'react'
 import cx from 'classnames'
 import { EbayNoticeContent } from '../ebay-notice-base/components/ebay-notice-content'
 import NoticeContent from '../common/notice-utils/notice-content'
-import EbayIcon from '../ebay-icon/icon'
+import { EbayIcon, Icon } from '../ebay-icon'
 
 type Props = React.HTMLProps<HTMLElement> & {
     status?: 'general' | 'none' | 'attention' | 'confirmation' | 'information';
@@ -37,7 +37,7 @@ const EbaySectionNotice: FC<Props> = ({
             aria-roledescription={ariaRoleDescription}>
             {hasStatus && (
                 <div className="section-notice__header" id={`section-notice-${status}`}>
-                    <EbayIcon name={`${status}-filled` as any} a11yText={ariaLabel} a11yVariant="label" />
+                    <EbayIcon name={`${status}FilledSmall` as Icon} a11yText={ariaLabel} a11yVariant="label" />
                 </div>
             )}
             <NoticeContent {...content.props} type="section" />


### PR DESCRIPTION
This will fix issue #77 , which will make the icon smaller on page notice, section notice, and inline notice, based on the Skin v14.12.0 changes.