### PR TITLE
EbayListboxButton: Use new btn--form element instead of expand-button

### DIFF
--- a/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -7,17 +7,17 @@ exports[`Storyshots ebay-listbox-button Borderless 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="listbox"
-    className="expand-btn expand-btn--borderless"
+    className="btn btn--form btn--borderless"
     onClick={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
     type="button"
   >
     <span
-      className="expand-btn__cell"
+      className="btn__cell"
     >
       <span
-        className="expand-btn__text"
+        className="btn__text"
       >
         Option 2
       </span>
@@ -60,17 +60,17 @@ exports[`Storyshots ebay-listbox-button Default - no selected option 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="listbox"
-    className="expand-btn"
+    className="btn btn--form"
     onClick={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
     type="button"
   >
     <span
-      className="expand-btn__cell"
+      className="btn__cell"
     >
       <span
-        className="expand-btn__text"
+        className="btn__text"
       >
         Option 1
       </span>
@@ -122,17 +122,17 @@ Array [
       aria-expanded={false}
       aria-haspopup="listbox"
       aria-labelledby="listbox-button__label expand-btn-text"
-      className="expand-btn"
+      className="btn btn--form"
       onClick={[Function]}
       onKeyUp={[Function]}
       onMouseDown={[Function]}
       type="button"
     >
       <span
-        className="expand-btn__cell"
+        className="btn__cell"
       >
         <span
-          className="expand-btn__text"
+          className="btn__text"
           id="expand-btn-text"
         >
           Option 2
@@ -177,17 +177,17 @@ exports[`Storyshots ebay-listbox-button Default 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="listbox"
-    className="expand-btn"
+    className="btn btn--form"
     onClick={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
     type="button"
   >
     <span
-      className="expand-btn__cell"
+      className="btn__cell"
     >
       <span
-        className="expand-btn__text"
+        className="btn__text"
       >
         Option 2
       </span>
@@ -230,7 +230,7 @@ exports[`Storyshots ebay-listbox-button Disabled State 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="listbox"
-    className="expand-btn"
+    className="btn btn--form"
     disabled={true}
     onClick={[Function]}
     onKeyUp={[Function]}
@@ -238,10 +238,10 @@ exports[`Storyshots ebay-listbox-button Disabled State 1`] = `
     type="button"
   >
     <span
-      className="expand-btn__cell"
+      className="btn__cell"
     >
       <span
-        className="expand-btn__text"
+        className="btn__text"
       >
         Option 2
       </span>
@@ -284,22 +284,22 @@ exports[`Storyshots ebay-listbox-button Floating label 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="listbox"
-    className="expand-btn expand-btn--floating-label"
+    className="btn btn--form btn--floating-label"
     onClick={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
     type="button"
   >
     <span
-      className="expand-btn__cell"
+      className="btn__cell"
     >
       <span
-        className="expand-btn__floating-label"
+        className="btn__floating-label"
       >
         Select
       </span>
       <span
-        className="expand-btn__text"
+        className="btn__text"
       >
         Option 1
       </span>
@@ -342,17 +342,17 @@ exports[`Storyshots ebay-listbox-button Fluid 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="listbox"
-    className="expand-btn"
+    className="btn btn--form"
     onClick={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
     type="button"
   >
     <span
-      className="expand-btn__cell"
+      className="btn__cell"
     >
       <span
-        className="expand-btn__text"
+        className="btn__text"
       >
         Option 2
       </span>
@@ -396,17 +396,17 @@ exports[`Storyshots ebay-listbox-button Invalid State 1`] = `
     aria-expanded={false}
     aria-haspopup="listbox"
     aria-invalid="true"
-    className="expand-btn"
+    className="btn btn--form"
     onClick={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
     type="button"
   >
     <span
-      className="expand-btn__cell"
+      className="btn__cell"
     >
       <span
-        className="expand-btn__text"
+        className="btn__text"
       >
         Option 2
       </span>
@@ -450,17 +450,17 @@ exports[`Storyshots ebay-listbox-button Statefull component 1`] = `
     <button
       aria-expanded={false}
       aria-haspopup="listbox"
-      className="expand-btn"
+      className="btn btn--form"
       onClick={[Function]}
       onKeyUp={[Function]}
       onMouseDown={[Function]}
       type="button"
     >
       <span
-        className="expand-btn__cell"
+        className="btn__cell"
       >
         <span
-          className="expand-btn__text"
+          className="btn__text"
         >
           California
         </span>
@@ -528,17 +528,17 @@ exports[`Storyshots ebay-listbox-button Too many options 1`] = `
   <button
     aria-expanded={false}
     aria-haspopup="listbox"
-    className="expand-btn"
+    className="btn btn--form"
     onClick={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
     type="button"
   >
     <span
-      className="expand-btn__cell"
+      className="btn__cell"
     >
       <span
-        className="expand-btn__text"
+        className="btn__text"
       >
         Option 2
       </span>

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -196,9 +196,9 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
                 : optionsByIndexRef.current.set(index, optionNode)
         }))
     const wrapperClassName = classNames('listbox-button', className, { 'listbox-button--fluid': fluid })
-    const buttonClassName = classNames('expand-btn', {
-        'expand-btn--borderless': borderless,
-        'expand-btn--floating-label': floatingLabel
+    const buttonClassName = classNames('btn btn--form', {
+        'btn--borderless': borderless,
+        'btn--floating-label': floatingLabel
     })
     const expandBtnTextId = prefixId && 'expand-btn-text'
 
@@ -217,13 +217,13 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
                 onKeyUp={onButtonKeyup}
                 ref={buttonRef}
             >
-                <span className="expand-btn__cell">
+                <span className="btn__cell">
                     {floatingLabel ? (
-                        <span className="expand-btn__floating-label">
+                        <span className="btn__floating-label">
                             {floatingLabel}
                         </span>
                     ) : null}
-                    <span className="expand-btn__text" id={expandBtnTextId}>{selectedOption.props.children}</span>
+                    <span className="btn__text" id={expandBtnTextId}>{selectedOption.props.children}</span>
                     <EbayIcon name="dropdown" />
                 </span>
             </button>


### PR DESCRIPTION
- Replace expand-btn with new btn--form css class

<img width="129" alt="Screen Shot 2022-10-04 at 3 48 30 PM" src="https://user-images.githubusercontent.com/2222191/193944628-c189a932-79c2-4a86-b53a-29d64129fc04.png">
