### PR TITLE
Make the page notice  a11yDismissText attribute optional

### DIFF
--- a/src/ebay-page-notice/page-notice.tsx
+++ b/src/ebay-page-notice/page-notice.tsx
@@ -6,7 +6,7 @@ import { EbayIcon, Icon } from '../ebay-icon'
 type Props = React.HTMLProps<HTMLElement> & {
     status?: 'general' | 'attention' | 'confirmation' | 'information',
     'aria-label'?: string,
-    a11yDismissText: string,
+    a11yDismissText?: string,
     onDismiss?: Dispatch<MouseEvent>
 };
 


### PR DESCRIPTION
The a11yDismissText attributes should have been optional, but it wasn't, which would cause issues if you were using strict typescript.