### PR TITLE
Issue 91: Update Page Notice stories to use EbayPageNoticeTitle #118

### DIFF
--- a/src/ebay-page-notice/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-page-notice/__tests__/__snapshots__/index.spec.tsx.snap
@@ -28,11 +28,13 @@ exports[`Storyshots ebay-page-notice Attention message 1`] = `
     <div
       class="page-notice__main"
     >
+      <h2
+        class="page-notice__title"
+      >
+        Error.
+      </h2>
       <p>
-        <strong>
-          Error.
-        </strong>
-          Please take another look at the following:
+        Please take another look at the following:
         <br />
         <a
           href="#"
@@ -86,11 +88,13 @@ exports[`Storyshots ebay-page-notice Confirmation message 1`] = `
     <div
       class="page-notice__main"
     >
+      <h2
+        class="page-notice__title"
+      >
+        Congrats!
+      </h2>
       <p>
-        <strong>
-          Congrats!
-        </strong>
-          You just listed 
+        You just listed 
         <a
           href="#"
         >
@@ -202,11 +206,13 @@ exports[`Storyshots ebay-page-notice Dismissible notice 1`] = `
     <div
       class="page-notice__main"
     >
+      <h2
+        class="page-notice__title"
+      >
+        Good news!
+      </h2>
       <p>
-        <strong>
-          Good news!
-        </strong>
-          You get free shipping on your next pair of shoes! 
+        You get free shipping on your next pair of shoes! 
         <a
           href="#"
         >
@@ -268,11 +274,13 @@ exports[`Storyshots ebay-page-notice Information message 1`] = `
     <div
       class="page-notice__main"
     >
+      <h2
+        class="page-notice__title"
+      >
+        Good news!
+      </h2>
       <p>
-        <strong>
-          Good news!
-        </strong>
-          You get free shipping on your next pair of shoes! 
+        You get free shipping on your next pair of shoes! 
         <a
           href="#"
         >

--- a/src/ebay-page-notice/__tests__/index.stories.tsx
+++ b/src/ebay-page-notice/__tests__/index.stories.tsx
@@ -13,8 +13,8 @@ storiesOf(`ebay-page-notice`, module)
     .add(`Confirmation message`, () => (<>
         <EbayPageNotice status="confirmation" aria-label="Success">
             <EbayNoticeContent>
+                <EbayPageNoticeTitle>Congrats!</EbayPageNoticeTitle>
                 <p>
-                    <strong>Congrats!</strong>&nbsp;
                     You just listed <a href="#">Spam and Eggs From the Cows Perspective</a> (paperback).
                 </p>
             </EbayNoticeContent>
@@ -24,8 +24,8 @@ storiesOf(`ebay-page-notice`, module)
     .add(`Information message`, () => (<>
         <EbayPageNotice status="information" aria-label="Information">
             <EbayNoticeContent>
+                <EbayPageNoticeTitle>Good news!</EbayPageNoticeTitle>
                 <p>
-                    <strong>Good news!</strong>&nbsp;
                     You get free shipping on your next pair of shoes! <a href="#">Learn more</a>.
                 </p>
             </EbayNoticeContent>
@@ -35,8 +35,8 @@ storiesOf(`ebay-page-notice`, module)
     .add(`Attention message`, () => (<>
         <EbayPageNotice status="attention" aria-label="Attention">
             <EbayNoticeContent>
+                <EbayPageNoticeTitle>Error.</EbayPageNoticeTitle>
                 <p>
-                    <strong>Error.</strong>&nbsp;
                     Please take another look at the following:<br />
                     <a href="#">Card number</a>, <a href="#">Expiration date</a> &amp; <a href="#">Security code</a>.
                 </p>
@@ -59,8 +59,8 @@ storiesOf(`ebay-page-notice`, module)
     .add(`Dismissible notice`, () => (<>
         <EbayPageNotice status="information" aria-label="Information" a11yDismissText="Close">
             <EbayNoticeContent>
+                <EbayPageNoticeTitle>Good news!</EbayPageNoticeTitle>
                 <p>
-                    <strong>Good news!</strong>&nbsp;
                     You get free shipping on your next pair of shoes! <a href="#">Learn more</a>.
                 </p>
             </EbayNoticeContent>


### PR DESCRIPTION
Many of the page-notice examples were using strong tags for a header instead of using EbayPageNoticeTitle. Updated these stories and their snapshots.

fixes https://github.com/eBay/ebayui-core-react/issues/91

This time without all the extra stuff that came along when the branch was changed to 2.0.0.