### PR TITLE
Adding "button" type to button

### DIFF
--- a/src/ebay-drawer-dialog/components/drawer.tsx
+++ b/src/ebay-drawer-dialog/components/drawer.tsx
@@ -85,6 +85,7 @@ const EbayDrawerDialog: FC<EbayDrawerProps<any>> = ({
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
+            type="button"
         />
     )
 


### PR DESCRIPTION
Button without a type defaults to a "submit" action. If this drawer is hosted inside a form, it will submit the form instead of expanding. By setting the type to "button" we prevent that functionality.