### PR TITLE
FIX: Adding "button" type to button

### DIFF
--- a/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -21,6 +21,7 @@ exports[`Storyshots ebay-drawer-dialog Custom Focus 1`] = `
         <button
           aria-label="Maximize Drawer"
           class="drawer-dialog__handle"
+          type="button"
         />
         <div
           class="drawer-dialog__header"
@@ -96,6 +97,7 @@ exports[`Storyshots ebay-drawer-dialog Default 1`] = `
         <button
           aria-label="Maximize Drawer"
           class="drawer-dialog__handle"
+          type="button"
         />
         <div
           class="drawer-dialog__header"
@@ -462,6 +464,7 @@ exports[`Storyshots ebay-drawer-dialog Lots Of Content 1`] = `
         <button
           aria-label="Maximize Drawer"
           class="drawer-dialog__handle"
+          type="button"
         />
         <div
           class="drawer-dialog__header"
@@ -837,6 +840,7 @@ exports[`Storyshots ebay-drawer-dialog Opened 1`] = `
         <button
           aria-label="Maximize Drawer"
           class="drawer-dialog__handle"
+          type="button"
         />
         <div
           class="drawer-dialog__header"
@@ -913,6 +917,7 @@ exports[`Storyshots ebay-drawer-dialog With Animation 1`] = `
         <button
           aria-label="Maximize Drawer"
           class="drawer-dialog__handle"
+          type="button"
         />
         <div
           class="drawer-dialog__header"

--- a/src/ebay-drawer-dialog/components/drawer.tsx
+++ b/src/ebay-drawer-dialog/components/drawer.tsx
@@ -85,6 +85,7 @@ const EbayDrawerDialog: FC<EbayDrawerProps<any>> = ({
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
             onTouchEnd={handleTouchEnd}
+            type="button"
         />
     )
 


### PR DESCRIPTION
Button without a type defaults to a "submit" action. If this drawer is hosted inside a form, it will submit the form instead of expanding. By setting the type to "button" we prevent that functionality.