### PR TITLE
[#24] Fix ignored `a11yCloseText` in fullscreen dialog...

### DIFF
--- a/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/src/ebay-dialog-base/components/dialogBase.tsx
@@ -35,7 +35,7 @@ export interface DialogBaseProps<T> extends HTMLProps<T> {
     top?: ReactElement;
     buttonPosition?: ButtonPosition;
     ariaLabelledby?: string;
-    a11yCloseText?: string;
+    a11yCloseText: string;
     onCloseBtnClick?: MouseEventHandler;
     onBackgroundClick?: MouseEventHandler;
     mainId?: string;

--- a/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -849,6 +849,7 @@ exports[`Storyshots ebay-drawer-dialog Opened 1`] = `
             id="dialog-title-abc123"
           />
           <button
+            aria-label="Close drawer"
             class="icon-btn drawer-dialog__close"
             type="button"
           >

--- a/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -19,7 +19,6 @@ exports[`Storyshots ebay-drawer-dialog Custom Focus 1`] = `
         class="drawer-dialog__window drawer-dialog__window drawer-dialog__window--slide"
       >
         <button
-          aria-label="Maximize Drawer"
           class="drawer-dialog__handle"
           type="button"
         />
@@ -95,7 +94,6 @@ exports[`Storyshots ebay-drawer-dialog Default 1`] = `
         class="drawer-dialog__window drawer-dialog__window drawer-dialog__window--slide"
       >
         <button
-          aria-label="Maximize Drawer"
           class="drawer-dialog__handle"
           type="button"
         />
@@ -462,7 +460,6 @@ exports[`Storyshots ebay-drawer-dialog Lots Of Content 1`] = `
         class="drawer-dialog__window drawer-dialog__window drawer-dialog__window--slide"
       >
         <button
-          aria-label="Maximize Drawer"
           class="drawer-dialog__handle"
           type="button"
         />
@@ -838,7 +835,6 @@ exports[`Storyshots ebay-drawer-dialog Opened 1`] = `
           tabindex="0"
         />
         <button
-          aria-label="Maximize Drawer"
           class="drawer-dialog__handle"
           type="button"
         />
@@ -916,7 +912,6 @@ exports[`Storyshots ebay-drawer-dialog Trigger Expanded 1`] = `
         class="drawer-dialog__window drawer-dialog__window drawer-dialog__window--slide"
       >
         <button
-          aria-label="Maximize Drawer"
           class="drawer-dialog__handle"
           type="button"
         />

--- a/src/ebay-drawer-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-drawer-dialog/__tests__/index.stories.tsx
@@ -29,7 +29,7 @@ export const _Default = () => {
 };
 
 export const _Opened = () => (<>
-    <EbayDrawerDialog open onClose={action('Close button clicked.')}>
+    <EbayDrawerDialog open onClose={action('Close button clicked.')} a11yCloseText="Close drawer">
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore
             et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
             aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse

--- a/src/ebay-drawer-dialog/components/drawer.tsx
+++ b/src/ebay-drawer-dialog/components/drawer.tsx
@@ -10,9 +10,8 @@ export interface EbayDrawerProps<T> extends DialogBaseProps<T> {
     open?: boolean;
     noHandle?: boolean;
     focus?: RefObject<HTMLAnchorElement & HTMLButtonElement>;
-    a11yCloseText?: string;
-    a11yMinimizeText?: string;
-    a11yMaximizeText?: string;
+    a11yMinimizeText: string;
+    a11yMaximizeText: string;
     onShow?: () => void;
     onClose?: () => void;
     onExpanded?: () => void;
@@ -25,8 +24,8 @@ const EbayDrawerDialog: FC<EbayDrawerProps<any>> = ({
     onClose = () => {},
     onCollapsed = () => {},
     onExpanded = () => {},
-    a11yMaximizeText = 'Maximize Drawer',
-    a11yMinimizeText = 'Minimize Drawer',
+    a11yMaximizeText,
+    a11yMinimizeText,
     children,
     ...rest
 }) => {

--- a/src/ebay-fullscreen-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-fullscreen-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -38,6 +38,7 @@ exports[`Storyshots ebay-fullscreen-dialog Always Opened 1`] = `
             class="fullscreen-dialog__header"
           >
             <button
+              aria-label="Close dialog"
               class="icon-btn fullscreen-dialog__close"
               type="button"
             >

--- a/src/ebay-fullscreen-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-fullscreen-dialog/__tests__/index.stories.tsx
@@ -26,7 +26,7 @@ export const _Default = () => {
 export const _AlwaysOpened = () => (
     <div>
         <p>Some outside content...</p>
-        <EbayFullscreenDialog open={true}>
+        <EbayFullscreenDialog open={true} a11yCloseText="Close dialog">
             <EbayDialogHeader>Heading</EbayDialogHeader>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>

--- a/src/ebay-fullscreen-dialog/fullscreen-dialog.tsx
+++ b/src/ebay-fullscreen-dialog/fullscreen-dialog.tsx
@@ -14,7 +14,6 @@ const EbayFullscreenDialog: FC<Props> = ({
     open,
     onClose = () => {},
     onOpen = () => {},
-    a11yCloseText = 'Close Dialog',
     className,
     animated,
     ...rest

--- a/src/ebay-lightbox-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-lightbox-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -43,7 +43,7 @@ exports[`Storyshots ebay-lightbox-dialog Always Opened 1`] = `
               Heading
             </h2>
             <button
-              aria-label="Close Dialog"
+              aria-label="Close dialog"
               class="icon-btn lightbox-dialog__close"
               type="button"
             >
@@ -123,7 +123,6 @@ exports[`Storyshots ebay-lightbox-dialog Default 1`] = `
               Heading
             </h2>
             <button
-              aria-label="Close Dialog"
               class="icon-btn lightbox-dialog__close"
               type="button"
             >
@@ -204,7 +203,6 @@ exports[`Storyshots ebay-lightbox-dialog Disable Dialog Close 1`] = `
               Heading
             </h2>
             <button
-              aria-label="Close Dialog"
               class="icon-btn lightbox-dialog__close"
               type="button"
             >
@@ -350,7 +348,6 @@ exports[`Storyshots ebay-lightbox-dialog Mini Dialog 1`] = `
               id="dialog-title-abc123"
             />
             <button
-              aria-label="Close Dialog"
               class="icon-btn lightbox-dialog__close"
               type="button"
             >
@@ -435,7 +432,6 @@ exports[`Storyshots ebay-lightbox-dialog Scrolling Content 1`] = `
               Heading
             </h2>
             <button
-              aria-label="Close Dialog"
               class="icon-btn lightbox-dialog__close"
               type="button"
             >
@@ -542,7 +538,6 @@ exports[`Storyshots ebay-lightbox-dialog With Animation 1`] = `
               Heading
             </h2>
             <button
-              aria-label="Close Dialog"
               class="icon-btn lightbox-dialog__close"
               type="button"
             >

--- a/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
@@ -36,7 +36,7 @@ export const _Default = () => {
 export const _AlwaysOpened = () => (
     <div>
         <p>Some outside content...</p>
-        <EbayLightboxDialog open>
+        <EbayLightboxDialog open a11yCloseText="Close dialog">
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>

--- a/src/ebay-lightbox-dialog/lightbox-dialog.tsx
+++ b/src/ebay-lightbox-dialog/lightbox-dialog.tsx
@@ -14,7 +14,6 @@ export interface Props<T = any> extends DialogBaseProps<T> {
 }
 
 const EbayLightboxDialog: FC<Props> = ({
-    a11yCloseText = 'Close Dialog',
     open,
     mode,
     onClose = () => {},
@@ -24,7 +23,6 @@ const EbayLightboxDialog: FC<Props> = ({
     <DialogBaseWithState
         buttonPosition="right"
         {...rest}
-        a11yCloseText={a11yCloseText}
         classPrefix={classPrefix}
         onCloseBtnClick={onClose}
         onBackgroundClick={onClose}

--- a/src/ebay-panel-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-panel-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -44,6 +44,7 @@ exports[`Storyshots ebay-panel-dialog Always Opened 1`] = `
               Heading
             </h2>
             <button
+              aria-label="Close panel"
               class="icon-btn panel-dialog__close"
               type="button"
             >

--- a/src/ebay-panel-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-panel-dialog/__tests__/index.stories.tsx
@@ -33,7 +33,7 @@ export const _Default = () => {
 export const _AlwaysOpened = () => (
     <div>
         <p>Some outside content...</p>
-        <EbayPanelDialog open>
+        <EbayPanelDialog open a11yCloseText="Close panel">
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
             <p><a href="http://www.ebay.com">www.ebay.com</a></p>


### PR DESCRIPTION
- fix ignored a11yCloseText in fullscreen dialog
- update dialog stories with close a11y text
- make all a11y text props required for dialogs like in ebayui-marko.

fixes #24 

storybook: https://opensource.ebay.com/ebayui-core-react/fix/dialog-close-a11y/index.html?path=/story/ebay-fullscreen-dialog--always-opened