### PR TITLE
[#54] EbayDrawer: make `expandable` a controlled prop

### DIFF
--- a/src/ebay-drawer-dialog/README.md
+++ b/src/ebay-drawer-dialog/README.md
@@ -25,8 +25,8 @@ import '@ebay/skin/drawer-dialog.css'
 
 Name | Type | Stateful | Required | Description
 --- | --- | --- | --- | ---
-`expanded` | Boolean | No | No | Whether the drawer is expanded to full height or max 50%
-`open` | Boolean | Yes | No | Whether drawer is open.
+`expanded` | Boolean | No | No | Whether the drawer is expanded to full height or max 50%. Controlled.
+`open` | Boolean | Yes | No | Whether drawer is open. Controlled.
 `noHandle` | Boolean | Yes | No | Whether handle will be shown or not.
 `focus` | String | No | No | An id for an element which will receive focus when the drawer opens (defaults to close button).
 `a11yCloseText` | String | No | Yes | A11y text for close button and mask.

--- a/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -896,7 +896,7 @@ exports[`Storyshots ebay-drawer-dialog Opened 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Storyshots ebay-drawer-dialog With Animation 1`] = `
+exports[`Storyshots ebay-drawer-dialog Trigger Expanded 1`] = `
 <DocumentFragment>
   <button
     class="btn btn--secondary"
@@ -947,19 +947,27 @@ exports[`Storyshots ebay-drawer-dialog With Animation 1`] = `
           class="drawer-dialog__main"
         >
           <p>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+            Trigger Dialog Expanded programmatically.
           </p>
-          <p>
-            <a
-              href="http://www.ebay.com"
-            >
-              www.ebay.com
-            </a>
-          </p>
+          <button
+            class="btn btn--secondary"
+          >
+            Expand Drawer
+          </button>
         </div>
       </div>
     </div>
   </div>
+</DocumentFragment>
+`;
+
+exports[`Storyshots ebay-drawer-dialog Without Animation 1`] = `
+<DocumentFragment>
+  <button
+    class="btn btn--secondary"
+  >
+    Open Drawer
+  </button>
 </DocumentFragment>
 `;
 

--- a/src/ebay-drawer-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-drawer-dialog/__tests__/index.stories.tsx
@@ -95,17 +95,37 @@ export const _CustomFocus = () => {
     );
 };
 
-export const _WithAnimation = () => {
+export const _WithoutAnimation = () => {
     const [open, setOpen] = useState(false);
 
     return (
         <>
             <EbayButton onClick={() => setOpen(!open)}>Open Drawer</EbayButton>
-            <EbayDrawerDialog open={open} onClose={() => setOpen(false)} animated>
+            <EbayDrawerDialog open={open} onClose={() => setOpen(false)} animated={false}>
                 <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
                 <p>
                     <a href="http://www.ebay.com">www.ebay.com</a>
                 </p>
+            </EbayDrawerDialog>
+        </>
+    );
+};
+
+export const _TriggerExpanded = () => {
+    const [open, setOpen] = useState(false);
+    const [expanded, setExpanded] = useState(false);
+
+    return (
+        <>
+            <EbayButton onClick={() => setOpen(!open)}>Open Drawer</EbayButton>
+            <EbayDrawerDialog open={open} onClose={() => setOpen(false)} expanded={expanded}>
+                <p>
+                    Trigger Dialog Expanded programmatically.
+                </p>
+
+                <EbayButton onClick={() => setExpanded(!expanded)} priority="secondary">
+                    {expanded ? "Collapse Drawer" : "Expand Drawer"}
+                </EbayButton>
             </EbayDrawerDialog>
         </>
     );

--- a/src/ebay-drawer-dialog/components/drawer.tsx
+++ b/src/ebay-drawer-dialog/components/drawer.tsx
@@ -1,4 +1,4 @@
-import React, { Children, FC, ReactElement, RefObject, Touch, TouchEvent, useState } from 'react'
+import React, { Children, FC, ReactElement, RefObject, Touch, TouchEvent, useEffect, useState } from 'react'
 import classNames from 'classnames'
 import { DialogBaseProps, DialogBaseWithState, EbayDialogHeader } from '../../ebay-dialog-base'
 
@@ -20,7 +20,7 @@ export interface EbayDrawerProps<T> extends DialogBaseProps<T> {
 }
 
 const EbayDrawerDialog: FC<EbayDrawerProps<any>> = ({
-    expanded: defaultExpanded = false,
+    expanded: controlledExpanded = false,
     noHandle,
     onClose = () => {},
     onCollapsed = () => {},
@@ -31,7 +31,11 @@ const EbayDrawerDialog: FC<EbayDrawerProps<any>> = ({
     ...rest
 }) => {
     let touches: Partial<Touch>[] = []
-    const [expanded, setExpanded] = useState(defaultExpanded)
+    const [expanded, setExpanded] = useState(controlledExpanded)
+
+    useEffect(() => {
+        setExpanded(controlledExpanded)
+    }, [controlledExpanded])
 
     const setExpandedState = (expand: boolean) => {
         setExpanded(expand)


### PR DESCRIPTION
fixed #54 

updated stories and readme

storybook: https://opensource.ebay.com/ebayui-core-react/fix/drawer-expandable/index.html?path=/story/ebay-drawer-dialog--trigger-expanded
