### PR TITLE
(fix) EbayButton: fix icon and expand use cases

### DIFF
--- a/src/ebay-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -216,7 +216,7 @@ exports[`Storyshots ebay-button Fixed height 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Storyshots ebay-button Flexible Button 1`] = `
+exports[`Storyshots ebay-button Flex Button 1`] = `
 <DocumentFragment>
   <button
     class="btn btn--primary btn--fluid"
@@ -291,12 +291,14 @@ exports[`Storyshots ebay-button Form button 1`] = `
 </DocumentFragment>
 `;
 
-exports[`Storyshots ebay-button Icon Button 1`] = `
+exports[`Storyshots ebay-button Icon Only 1`] = `
 <DocumentFragment>
   <p>
+    Form button:
+    <br />
     <button
       aria-label="Menu button"
-      class="btn btn--primary btn--icon-only"
+      class="btn btn--form btn--slim"
     >
       <svg
         aria-hidden="true"
@@ -313,28 +315,11 @@ exports[`Storyshots ebay-button Icon Button 1`] = `
     </button>
   </p>
   <p>
-    <button
-      aria-label="Settings button"
-      class="btn btn--secondary btn--icon-only"
-    >
-      <svg
-        aria-hidden="true"
-        class="icon icon--settings"
-        focusable="false"
-        height="24px"
-        width="24px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <use
-          xlink:href="#icon-settings"
-        />
-      </svg>
-    </button>
-  </p>
-  <p>
+    Form fake-button (link):
+    <br />
     <a
       aria-label="Settings link"
-      class="fake-btn fake-btn--secondary fake-btn--icon-only"
+      class="fake-btn fake-btn--form fake-btn--slim"
       href="#"
     >
       <svg
@@ -352,9 +337,11 @@ exports[`Storyshots ebay-button Icon Button 1`] = `
     </a>
   </p>
   <p>
+    Delete button:
+    <br />
     <button
       aria-label="Destructive button"
-      class="btn btn--secondary btn--destructive btn--icon-only"
+      class="btn btn--secondary btn--destructive btn--slim"
     >
       <svg
         aria-hidden="true"
@@ -378,7 +365,123 @@ exports[`Storyshots ebay-button Loading button 1`] = `
   <p>
     <button
       aria-live="polite"
+      class="btn btn--secondary"
+    >
+      <span
+        class="btn__cell"
+      >
+        <span
+          aria-label="Busy"
+          class="progress-spinner"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon icon--spinner"
+            focusable="false"
+            height="24px"
+            width="24px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="#icon-spinner"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+  </p>
+  <p>
+    <button
+      aria-live="polite"
       class="btn btn--primary"
+    >
+      <span
+        class="btn__cell"
+      >
+        <span
+          aria-label="Busy"
+          class="progress-spinner"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon icon--spinner"
+            focusable="false"
+            height="24px"
+            width="24px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="#icon-spinner"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+  </p>
+  <p>
+    <button
+      aria-live="polite"
+      class="btn btn--tertiary"
+    >
+      <span
+        class="btn__cell"
+      >
+        <span
+          aria-label="Busy"
+          class="progress-spinner"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon icon--spinner"
+            focusable="false"
+            height="24px"
+            width="24px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="#icon-spinner"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+  </p>
+  <p>
+    <button
+      aria-live="polite"
+      class="btn btn--form"
+    >
+      <span
+        class="btn__cell"
+      >
+        <span
+          aria-label="Busy"
+          class="progress-spinner"
+          role="img"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon icon--spinner"
+            focusable="false"
+            height="24px"
+            width="24px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="#icon-spinner"
+            />
+          </svg>
+        </span>
+      </span>
+    </button>
+  </p>
+  <p>
+    <button
+      aria-live="polite"
+      class="btn btn--secondary btn--destructive"
     >
       <span
         class="btn__cell"
@@ -565,24 +668,154 @@ exports[`Storyshots ebay-button Transparent 1`] = `
 
 exports[`Storyshots ebay-button Truncated 1`] = `
 <DocumentFragment>
-  <div
-    style="max-width: 200px;"
-  >
+  <div>
     <p>
       <button
         class="btn btn--secondary btn--truncated"
+        style="max-width: 200px;"
       >
         Hello, I am a button! this is a long text
+      </button>
+    </p>
+    <p>
+      <button
+        class="btn btn--secondary btn--large btn--truncated"
+        style="max-width: 200px;"
+      >
+        Hello, I am a BIG button! this is a long text
       </button>
     </p>
     <p>
       <a
         class="fake-btn fake-btn--secondary fake-btn--truncated"
         href="https://ebay.com"
+        style="max-width: 200px;"
       >
         Hello, I am a link! this is a long text
       </a>
     </p>
   </div>
+</DocumentFragment>
+`;
+
+exports[`Storyshots ebay-button With icon 1`] = `
+<DocumentFragment>
+  <p>
+    Form button:
+    <br />
+    <button
+      aria-label="Menu button"
+      class="btn btn--secondary"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--menu"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-menu"
+        />
+      </svg>
+      <span>
+        Button with icon
+      </span>
+    </button>
+  </p>
+  <p>
+    Form fake-button (link):
+    <br />
+    <a
+      aria-label="Settings link"
+      class="fake-btn fake-btn--form"
+      href="#"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--settings"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-settings"
+        />
+      </svg>
+      <span>
+        Button with icon
+      </span>
+    </a>
+  </p>
+  <p>
+    Delete button:
+    <br />
+    <button
+      aria-label="Destructive button"
+      class="btn btn--secondary btn--destructive"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--delete"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-delete"
+        />
+      </svg>
+      <span>
+        Button with icon
+      </span>
+    </button>
+  </p>
+  <p>
+    Expand button:
+    <br />
+    <button
+      aria-label="Destructive button"
+      class="btn btn--secondary"
+    >
+      <span
+        class="btn__cell"
+      >
+        <span
+          class="btn__text"
+        >
+          <svg
+            aria-hidden="true"
+            class="icon icon--settings"
+            focusable="false"
+            height="24px"
+            width="24px"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <use
+              xlink:href="#icon-settings"
+            />
+          </svg>
+          <span>
+            Expand button
+          </span>
+        </span>
+        <svg
+          aria-hidden="true"
+          class="icon icon--dropdown"
+          focusable="false"
+          height="24px"
+          width="24px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="#icon-dropdown"
+          />
+        </svg>
+      </span>
+    </button>
+  </p>
 </DocumentFragment>
 `;

--- a/src/ebay-button/__tests__/index.stories.tsx
+++ b/src/ebay-button/__tests__/index.stories.tsx
@@ -52,18 +52,35 @@ storiesOf(`ebay-button`, module)
             <p><EbayButton fluid href="https://www.ebay.com">Link</EbayButton></p>
         </>
     ))
-    .add(`Icon Button`, () => (
+    .add(`With icon`, () => (
         <>
-            <p><EbayButton priority="primary" aria-label="Menu button">
+            <p>Form button:<br/><EbayButton aria-label="Menu button">
+                <EbayIcon name="menu" />
+                <span>Button with icon</span>
+            </EbayButton></p>
+            <p>Form fake-button (link):<br/><EbayButton href="#" variant="form" aria-label="Settings link">
+                <EbayIcon name="settings" />
+                <span>Button with icon</span>
+            </EbayButton></p>
+            <p>Delete button:<br/><EbayButton variant="destructive" aria-label="Destructive button">
+                <EbayIcon name="delete" />
+                <span>Button with icon</span>
+            </EbayButton></p>
+            <p>Expand button:<br/><EbayButton bodyState="expand" aria-label="Destructive button">
+                <EbayIcon name="settings" />
+                <span>Expand button</span>
+            </EbayButton></p>
+            </>
+    ))
+    .add(`Icon Only`, () => (
+        <>
+            <p>Form button:<br/><EbayButton variant="form" aria-label="Menu button">
                 <EbayIcon name="menu" />
             </EbayButton></p>
-            <p><EbayButton aria-label="Settings button">
+            <p>Form fake-button (link):<br/><EbayButton href="#" variant="form" aria-label="Settings link">
                 <EbayIcon name="settings" />
             </EbayButton></p>
-            <p><EbayButton href="#" aria-label="Settings link">
-                <EbayIcon name="settings" />
-            </EbayButton></p>
-            <p><EbayButton priority="secondary" variant="destructive" aria-label="Destructive button">
+            <p>Delete button:<br/><EbayButton variant="destructive" aria-label="Destructive button">
                 <EbayIcon name="delete" />
             </EbayButton></p>
             </>
@@ -92,7 +109,7 @@ storiesOf(`ebay-button`, module)
             <p><EbayButton href="https://ebay.com" truncate>Hello, I am a link! this is a long text</EbayButton></p>
         </div>
     ))
-    .add(`Flexible Button`, () => (
+    .add(`Flex Button`, () => (
         <EbayButton priority="primary" fluid>
             <EbayButtonCell style={{ justifyContent: 'space-between' }}>
                 <span>Select</span>
@@ -105,7 +122,11 @@ storiesOf(`ebay-button`, module)
     ))
     .add(`Loading button`, () => (
         <>
-            <p><EbayButton priority="primary" bodyState="loading">Primary Button</EbayButton></p>
+            <p><EbayButton bodyState="loading" /></p>
+            <p><EbayButton priority="primary" bodyState="loading" /></p>
+            <p><EbayButton priority="tertiary" bodyState="loading" /></p>
+            <p><EbayButton variant="form" bodyState="loading" /></p>
+            <p><EbayButton variant="destructive" bodyState="loading" /></p>
         </>
     ))
     .add(`Expand button`, () => (

--- a/src/ebay-button/__tests__/index.stories.tsx
+++ b/src/ebay-button/__tests__/index.stories.tsx
@@ -104,9 +104,10 @@ storiesOf(`ebay-button`, module)
         <EbayButton priority="primary" partiallyDisabled>Hello, I am a button!</EbayButton>
     ))
     .add(`Truncated`, () => (
-        <div style={{ maxWidth: '200px' }}>
-            <p><EbayButton truncate>Hello, I am a button! this is a long text</EbayButton></p>
-            <p><EbayButton href="https://ebay.com" truncate>Hello, I am a link! this is a long text</EbayButton></p>
+        <div>
+            <p><EbayButton truncate style={{ maxWidth: '200px' }}>Hello, I am a button! this is a long text</EbayButton></p>
+            <p><EbayButton size="large" truncate style={{ maxWidth: '200px' }}>Hello, I am a BIG button! this is a long text</EbayButton></p>
+            <p><EbayButton href="https://ebay.com" truncate style={{ maxWidth: '200px' }}>Hello, I am a link! this is a long text</EbayButton></p>
         </div>
     ))
     .add(`Flex Button`, () => (

--- a/src/ebay-button/button-expand.tsx
+++ b/src/ebay-button/button-expand.tsx
@@ -1,0 +1,15 @@
+import React, { FC } from 'react'
+import EbayButtonCell from './button-cell'
+import EbayButtonText from './button-text'
+import { EbayIcon } from '../ebay-icon'
+
+const EbayButtonExpand: FC = ({ children }) => (
+    <EbayButtonCell>
+        <EbayButtonText>
+            {children}
+        </EbayButtonText>
+        <EbayIcon name="dropdown" />
+    </EbayButtonCell>
+)
+
+export default EbayButtonExpand

--- a/src/ebay-button/button.tsx
+++ b/src/ebay-button/button.tsx
@@ -13,8 +13,7 @@ import { withForwardRef } from '../common/component-utils'
 import { Priority, Size, BodyState, Variant } from './types'
 import { EbayIcon } from '../ebay-icon'
 import EbayButtonLoading from './button-loading'
-import EbayButtonCell from './button-cell'
-import EbayButtonText from './button-text'
+import EbayButtonExpand from './button-expand'
 
 export type EbayButtonProps = {
     fluid?: boolean;
@@ -75,7 +74,6 @@ const EbayButton:FC<Props> = ({
     const isDestructive = variant === 'destructive'
     const isForm = variant === 'form'
     const isLoading = bodyState === 'loading'
-    const isExpand = bodyState === 'expand'
     const className = classNames(
         classPrefix,
         extraClasses,
@@ -83,7 +81,7 @@ const EbayButton:FC<Props> = ({
         sizeStyles[size],
         isDestructive && `${classPrefix}--destructive`,
         isForm && `${classPrefix}--form`,
-        iconOnly && `${classPrefix}--icon-only`,
+        iconOnly && `${classPrefix}--slim`,
         transparent && `${classPrefix}--transparent`,
         fluid && `${classPrefix}--fluid`,
         truncate && `${classPrefix}--truncated`,
@@ -97,19 +95,11 @@ const EbayButton:FC<Props> = ({
         }
     }
 
-    let bodyContent = children
-    if (isLoading) {
-        bodyContent = <EbayButtonLoading />
-    } else if (isExpand) {
-        bodyContent = (
-            <EbayButtonCell>
-                <EbayButtonText>
-                    {children}
-                </EbayButtonText>
-                <EbayIcon name="dropdown" />
-            </EbayButtonCell>
-        )
-    }
+    const bodyContent = {
+        loading: <EbayButtonLoading />,
+        expand: <EbayButtonExpand>{children}</EbayButtonExpand>
+    }[bodyState] || children
+
     const ariaLive = isLoading ? `polite` : null
 
     return href ? (


### PR DESCRIPTION
fixes #155 

- fixed use-case [icon-only](https://opensource.ebay.com/ebayui-core-react/fix-EbayButton/index.html?path=/story/ebay-button--icon-only)
- added use-case [with-icon](https://opensource.ebay.com/ebayui-core-react/fix-EbayButton/index.html?path=/story/ebay-button--with-icon)
- fixed [truncated story](https://opensource.ebay.com/ebayui-core-react/fix-EbayButton/index.html?path=/story/ebay-button--truncated)
- added more [loading button examples](https://opensource.ebay.com/ebayui-core-react/fix-EbayButton/index.html?path=/story/ebay-button--loading-button) and found a [skin bug](https://github.com/eBay/skin/issues/1940)
