### PR TITLE
FEAT: Use DrawerDialog on EbayInfotip as per skin spec

### DIFF
--- a/src/ebay-infotip/README.md
+++ b/src/ebay-infotip/README.md
@@ -12,7 +12,6 @@ import {
     EbayInfotipHost,
     EbayInfotipContent,
     EbayInfotipHeading,
-    EbayInfotipCloseButton,
 } from '@ebay/ui-core-react/ebay-infotip'
 ```
 
@@ -36,10 +35,9 @@ yarn add @ebay/ui-core-react
 
 ```jsx harmony
 <EbayInfotip>
+    <EbayInfotipHeading>Heading</EbayInfotipHeading>
     <EbayInfotipContent>
-        <EbayInfotipHeading>Heading</EbayInfotipHeading>
         <p>Here's a tip to help you be successful at your task.</p>
-        <EbayInfotipCloseButton aria-label="Dismiss info" />
     </EbayInfotipContent>
 </EbayInfotip>
 ```

--- a/src/ebay-infotip/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-infotip/__tests__/__snapshots__/index.spec.tsx.snap
@@ -521,22 +521,33 @@ exports[`Storyshots ebay-infotip Modal 1`] = `
         <div
           aria-labelledby="dialog-title-abc123"
           arial-modal="true"
-          class="lightbox-dialog dialog--mini__overlay lightbox-dialog--mask-fade"
+          class="drawer-dialog dialog--mini__overlay drawer-dialog--mask-fade-slow"
           hidden=""
+          mode="mini"
           role="dialog"
         >
           <div
-            class="lightbox-dialog__window lightbox-dialog__window--fade lightbox-dialog__window--mini"
+            class="drawer-dialog__window drawer-dialog__window drawer-dialog__window--slide"
           >
+            <button
+              class="drawer-dialog__handle"
+              type="button"
+            />
             <div
-              class="lightbox-dialog__header"
+              class="drawer-dialog__header"
             >
               <h2
                 id="dialog-title-abc123"
-              />
+              >
+                <span
+                  class="infotip__heading"
+                >
+                  Title
+                </span>
+              </h2>
               <button
                 aria-label="Close"
-                class="icon-btn lightbox-dialog__close"
+                class="icon-btn drawer-dialog__close"
                 type="button"
               >
                 <svg
@@ -554,7 +565,7 @@ exports[`Storyshots ebay-infotip Modal 1`] = `
               </button>
             </div>
             <div
-              class="lightbox-dialog__main"
+              class="drawer-dialog__main"
             >
               <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.

--- a/src/ebay-infotip/__tests__/index.stories.tsx
+++ b/src/ebay-infotip/__tests__/index.stories.tsx
@@ -67,6 +67,7 @@ storiesOf(`ebay-infotip`, module)
     .add(`Modal`, () => (
         <div style={{ width: '100%', margin: 100 }}>
             <EbayInfotip variant="modal" a11yCloseText="Close" aria-label="Infotip">
+                <EbayInfotipHeading>Title</EbayInfotipHeading>
                 <EbayInfotipContent>
                     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
                 </EbayInfotipContent>

--- a/src/ebay-infotip/ebay-infotip.tsx
+++ b/src/ebay-infotip/ebay-infotip.tsx
@@ -2,7 +2,7 @@ import React, { cloneElement, createElement, CSSProperties, FC, useRef, ReactNod
 import classNames from 'classnames'
 import { findComponent } from '../common/component-utils'
 import { Tooltip, TooltipHost, TooltipContent, PointerDirection, useTooltip } from '../common/tooltip-utils'
-import { EbayLightboxDialog } from '../ebay-lightbox-dialog'
+import { EbayDrawerDialog } from '../ebay-drawer-dialog'
 import { EbayDialogHeader } from '../ebay-dialog-base'
 import EbayInfotipHost from './ebay-infotip-host'
 import { Icon } from '../ebay-icon'
@@ -84,7 +84,7 @@ const EbayInfotip: FC<InfotipProps> = ({
                 })}
             </TooltipHost>
             {isModal ? (
-                <EbayLightboxDialog
+                <EbayDrawerDialog
                     {...contentProps}
                     open={isExpanded}
                     onClose={collapseTooltip}
@@ -92,9 +92,9 @@ const EbayInfotip: FC<InfotipProps> = ({
                     a11yCloseText={a11yCloseText}
                     className="dialog--mini__overlay"
                 >
-                    <EbayDialogHeader />
+                    <EbayDialogHeader>{heading}</EbayDialogHeader>
                     {contentChildren}
-                </EbayLightboxDialog>
+                </EbayDrawerDialog>
             ) : (
                 <TooltipContent
                     {...contentProps}


### PR DESCRIPTION
Latest skin versions changed to use a drawer dialog instead of lightbox dialog on infotip, this PR change this behavior and also fix the title to rendered in the right place of the dialog.
Also, updated EbayInfotip docs

Storybook: https://opensource.ebay.com/ebayui-core-react/hlimas/infotip-modal-style/index.html?path=/story/ebay-infotip--modal