### PR TITLE
EbayButton: add `split` prop

### DIFF
--- a/src/ebay-button/README.md
+++ b/src/ebay-button/README.md
@@ -51,10 +51,12 @@ Name | Type | Stateful | Required | Description | Data
 `href` | String | No | No | for link that looks like a button
 `fluid` | Boolean | No | No | takes the whole width of the parent element
 `disabled` | Boolean | Yes | No
-`partiallyDisabled` | Boolean | No | No | sets aria disabled but not disabled attribute
+`partiallyDisabled` | Boolean | No | No | sets `aria-disabled` but not `disabled` prop
 `transparent` | Boolean | Yes | No | transparent background color (overrides `priority` prop)
 `truncate` | Boolean | No | No | will truncate the text of the button onto a single line, and adds an ellipsis, when the button's text overflows
 `borderless` | Boolean | No | No | shows button without border
 `fixedHeight` | Boolean | No | No | fixes the height based on `size`
 `onClick` | Function | - | No | click or action key pressed (`Space` / `Enter`)
 `onEscape` | Function | - | No | `Esc`-key pressed
+`onFocus` | Function | - | No | triggered on focus
+`onBlur` | Function | - | No | triggered on blur

--- a/src/ebay-button/README.md
+++ b/src/ebay-button/README.md
@@ -52,9 +52,9 @@ Name | Type | Stateful | Required | Description | Data
 `fluid` | Boolean | No | No | takes the whole width of the parent element
 `disabled` | Boolean | Yes | No
 `partiallyDisabled` | Boolean | No | No | sets aria disabled but not disabled attribute
-`transparent` | Boolean | Yes | No | for transparent background
+`transparent` | Boolean | Yes | No | transparent background color (overrides `priority` prop)
 `truncate` | Boolean | No | No | will truncate the text of the button onto a single line, and adds an ellipsis, when the button's text overflows
-`borderless` | Boolean | No | No | Use the borderless modifier to remove the border from the expandable button.
-`fixedHeight` | Boolean | No | No | Fixes the height based on `size`.
+`borderless` | Boolean | No | No | shows button without border
+`fixedHeight` | Boolean | No | No | fixes the height based on `size`
 `onClick` | Function | - | No | click or action key pressed (`Space` / `Enter`)
 `onEscape` | Function | - | No | `Esc`-key pressed

--- a/src/ebay-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -122,7 +122,7 @@ exports[`Storyshots ebay-button Expand button 1`] = `
         <span
           class="btn__text"
         >
-          Expand button
+          Primary expand button
         </span>
         <svg
           aria-hidden="true"
@@ -138,8 +138,7 @@ exports[`Storyshots ebay-button Expand button 1`] = `
         </svg>
       </span>
     </button>
-  </p>
-  <p>
+
     <button
       aria-expanded="true"
       class="btn btn--primary"
@@ -169,7 +168,7 @@ exports[`Storyshots ebay-button Expand button 1`] = `
   </p>
   <p>
     <button
-      class="btn btn--borderless"
+      class="btn btn--secondary"
     >
       <span
         class="btn__cell"
@@ -177,7 +176,7 @@ exports[`Storyshots ebay-button Expand button 1`] = `
         <span
           class="btn__text"
         >
-          Expanded button
+          Expand button
         </span>
         <svg
           aria-hidden="true"
@@ -192,6 +191,191 @@ exports[`Storyshots ebay-button Expand button 1`] = `
           />
         </svg>
       </span>
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--tertiary"
+    >
+      <span
+        class="btn__cell"
+      >
+        <span
+          class="btn__text"
+        >
+          Tertiary expand button
+        </span>
+        <svg
+          aria-hidden="true"
+          class="icon icon--dropdown"
+          focusable="false"
+          height="24px"
+          width="24px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="#icon-dropdown"
+          />
+        </svg>
+      </span>
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--form"
+    >
+      <span
+        class="btn__cell"
+      >
+        <span
+          class="btn__text"
+        >
+          Form expand button
+        </span>
+        <svg
+          aria-hidden="true"
+          class="icon icon--dropdown"
+          focusable="false"
+          height="24px"
+          width="24px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="#icon-dropdown"
+          />
+        </svg>
+      </span>
+    </button>
+
+    <button
+      class="btn btn--form btn--slim"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--dropdown"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-dropdown"
+        />
+      </svg>
+    </button>
+
+    <button
+      aria-expanded="true"
+      class="btn btn--form btn--slim"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--dropdown"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-dropdown"
+        />
+      </svg>
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--borderless"
+    >
+      <span
+        class="btn__cell"
+      >
+        <span
+          class="btn__text"
+        >
+          Borderless expand button
+        </span>
+        <svg
+          aria-hidden="true"
+          class="icon icon--dropdown"
+          focusable="false"
+          height="24px"
+          width="24px"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <use
+            xlink:href="#icon-dropdown"
+          />
+        </svg>
+      </span>
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--primary btn--split-start"
+    >
+      Primary Split button
+    </button>
+    <button
+      class="btn btn--primary btn--split-end"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--dropdown"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-dropdown"
+        />
+      </svg>
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--secondary btn--split-start"
+    >
+      Split button
+    </button>
+    <button
+      class="btn btn--secondary btn--split-end"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--dropdown"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-dropdown"
+        />
+      </svg>
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--tertiary btn--split-start"
+    >
+      Tertiary split button
+    </button>
+    <button
+      class="btn btn--tertiary btn--split-end"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--dropdown"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-dropdown"
+        />
+      </svg>
     </button>
   </p>
 </DocumentFragment>
@@ -341,7 +525,7 @@ exports[`Storyshots ebay-button Icon Only 1`] = `
     <br />
     <button
       aria-label="Destructive button"
-      class="btn btn--secondary btn--destructive btn--slim"
+      class="btn btn--secondary btn--destructive"
     >
       <svg
         aria-hidden="true"
@@ -625,6 +809,117 @@ exports[`Storyshots ebay-button Size 1`] = `
       Default Size Link
     </a>
   </p>
+</DocumentFragment>
+`;
+
+exports[`Storyshots ebay-button Split button 1`] = `
+<DocumentFragment>
+  <p>
+    <button
+      class="btn btn--primary btn--split-start"
+    >
+      Primary split start button
+    </button>
+    <button
+      class="btn btn--primary btn--split-end"
+    >
+      Primary split end button
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--secondary btn--split-start"
+    >
+      Split start button
+    </button>
+    <button
+      class="btn btn--secondary btn--split-end"
+    >
+      Split end button
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--tertiary btn--split-start"
+    >
+      Tertiary split start button
+    </button>
+    <button
+      class="btn btn--tertiary btn--split-end"
+    >
+      Tertiary split end button
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--primary btn--split-start"
+    >
+      Primary Split button
+    </button>
+    <button
+      class="btn btn--primary btn--split-end"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--dropdown"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-dropdown"
+        />
+      </svg>
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--secondary btn--split-start"
+    >
+      Split button
+    </button>
+    <button
+      class="btn btn--secondary btn--split-end"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--dropdown"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-dropdown"
+        />
+      </svg>
+    </button>
+  </p>
+  <p>
+    <button
+      class="btn btn--tertiary btn--split-start"
+    >
+      Tertiary split button
+    </button>
+    <button
+      class="btn btn--tertiary btn--split-end"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--dropdown"
+        focusable="false"
+        height="24px"
+        width="24px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-dropdown"
+        />
+      </svg>
+    </button>
+  </p>
+          
 </DocumentFragment>
 `;
 

--- a/src/ebay-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -138,7 +138,7 @@ exports[`Storyshots ebay-button Expand button 1`] = `
         </svg>
       </span>
     </button>
-
+     
     <button
       aria-expanded="true"
       class="btn btn--primary"
@@ -246,7 +246,7 @@ exports[`Storyshots ebay-button Expand button 1`] = `
         </svg>
       </span>
     </button>
-
+     
     <button
       class="btn btn--form btn--slim"
     >
@@ -263,7 +263,7 @@ exports[`Storyshots ebay-button Expand button 1`] = `
         />
       </svg>
     </button>
-
+     
     <button
       aria-expanded="true"
       class="btn btn--form btn--slim"
@@ -307,75 +307,6 @@ exports[`Storyshots ebay-button Expand button 1`] = `
           />
         </svg>
       </span>
-    </button>
-  </p>
-  <p>
-    <button
-      class="btn btn--primary btn--split-start"
-    >
-      Primary Split button
-    </button>
-    <button
-      class="btn btn--primary btn--split-end"
-    >
-      <svg
-        aria-hidden="true"
-        class="icon icon--dropdown"
-        focusable="false"
-        height="24px"
-        width="24px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <use
-          xlink:href="#icon-dropdown"
-        />
-      </svg>
-    </button>
-  </p>
-  <p>
-    <button
-      class="btn btn--secondary btn--split-start"
-    >
-      Split button
-    </button>
-    <button
-      class="btn btn--secondary btn--split-end"
-    >
-      <svg
-        aria-hidden="true"
-        class="icon icon--dropdown"
-        focusable="false"
-        height="24px"
-        width="24px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <use
-          xlink:href="#icon-dropdown"
-        />
-      </svg>
-    </button>
-  </p>
-  <p>
-    <button
-      class="btn btn--tertiary btn--split-start"
-    >
-      Tertiary split button
-    </button>
-    <button
-      class="btn btn--tertiary btn--split-end"
-    >
-      <svg
-        aria-hidden="true"
-        class="icon icon--dropdown"
-        focusable="false"
-        height="24px"
-        width="24px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <use
-          xlink:href="#icon-dropdown"
-        />
-      </svg>
     </button>
   </p>
 </DocumentFragment>

--- a/src/ebay-button/__tests__/index.stories.tsx
+++ b/src/ebay-button/__tests__/index.stories.tsx
@@ -132,10 +132,49 @@ storiesOf(`ebay-button`, module)
     ))
     .add(`Expand button`, () => (
         <>
-            <p><EbayButton priority="primary" bodyState="expand">Expand button</EbayButton></p>
-            <p><EbayButton priority="primary" bodyState="expand" aria-expanded="true">Expanded button</EbayButton></p>
-            <p><EbayButton priority="primary" bodyState="expand" borderless>Expanded button</EbayButton></p>
+            <p>
+                <EbayButton priority="primary" bodyState="expand">Primary expand button</EbayButton>
+                {' '}
+                <EbayButton priority="primary" bodyState="expand" aria-expanded="true">Expanded button</EbayButton>
+            </p>
+            <p><EbayButton bodyState="expand">Expand button</EbayButton></p>
+            <p><EbayButton priority="tertiary" bodyState="expand">Tertiary expand button</EbayButton></p>
+            <p>
+                <EbayButton variant="form" bodyState="expand">Form expand button</EbayButton>
+                {' '}
+                <EbayButton variant="form" bodyState="expand" />
+                {' '}
+                <EbayButton variant="form" bodyState="expand" aria-expanded={true}/>
+            </p>
+            <p><EbayButton priority="primary" bodyState="expand" borderless>Borderless expand button</EbayButton></p>
         </>
+    ))
+    .add(`Split button`, () => (
+        <>
+            <p>
+                <EbayButton priority="primary" split="start">Primary split start button</EbayButton>
+                <EbayButton priority="primary" split="end">Primary split end button</EbayButton>
+            </p>
+            <p>
+                <EbayButton split="start">Split start button</EbayButton>
+                <EbayButton split="end">Split end button</EbayButton>
+            </p>
+            <p>
+                <EbayButton priority="tertiary" split="start">Tertiary split start button</EbayButton>
+                <EbayButton priority="tertiary" split="end">Tertiary split end button</EbayButton>
+            </p>
+            <p>
+                <EbayButton priority="primary" split="start">Primary Split button</EbayButton>
+                <EbayButton priority="primary" bodyState="expand" split="end" />
+            </p>
+            <p>
+                <EbayButton split="start">Split button</EbayButton>
+                <EbayButton bodyState="expand" split="end" />
+            </p>
+            <p>
+                <EbayButton priority="tertiary" split="start">Tertiary split button</EbayButton>
+                <EbayButton priority="tertiary" bodyState="expand" split="end" />
+            </p>        </>
     ))
     .add(`Form button`, () => (
         <>

--- a/src/ebay-button/button-expand.tsx
+++ b/src/ebay-button/button-expand.tsx
@@ -3,13 +3,16 @@ import EbayButtonCell from './button-cell'
 import EbayButtonText from './button-text'
 import { EbayIcon } from '../ebay-icon'
 
-const EbayButtonExpand: FC = ({ children }) => (
-    <EbayButtonCell>
-        <EbayButtonText>
-            {children}
-        </EbayButtonText>
+const EbayButtonExpand: FC = ({ children }) =>
+    children ? (
+        <EbayButtonCell>
+            <EbayButtonText>
+                {children}
+            </EbayButtonText>
+            <EbayIcon name="dropdown" />
+        </EbayButtonCell>
+    ) : (
         <EbayIcon name="dropdown" />
-    </EbayButtonCell>
-)
+    )
 
 export default EbayButtonExpand

--- a/src/ebay-button/types.ts
+++ b/src/ebay-button/types.ts
@@ -4,6 +4,6 @@ export type Variant = 'standard' | 'destructive' | 'form'
 
 export type Size = 'default' /* DEPRECATED */ | 'regular' | 'large'
 
-export type BodyState = 'loading' | 'expand'
+export type BodyState = 'loading' | 'expand' | 'reset' | 'none'
 
 export type Split = 'start' | 'end';

--- a/src/ebay-button/types.ts
+++ b/src/ebay-button/types.ts
@@ -5,3 +5,5 @@ export type Variant = 'standard' | 'destructive' | 'form'
 export type Size = 'default' /* DEPRECATED */ | 'regular' | 'large'
 
 export type BodyState = 'loading' | 'expand'
+
+export type Split = 'start' | 'end';

--- a/src/ebay-fake-menu-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-fake-menu-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -592,25 +592,18 @@ exports[`Storyshots ebay-fake-menu-button Without Text 1`] = `
     onClick={[Function]}
     onKeyDown={[Function]}
   >
-    <span
-      className="btn__cell"
+    <svg
+      aria-hidden={true}
+      className="icon icon--dropdown"
+      focusable={false}
+      height="24px"
+      width="24px"
+      xmlns="http://www.w3.org/2000/svg"
     >
-      <span
-        className="btn__text"
+      <use
+        xlinkHref="#icon-dropdown"
       />
-      <svg
-        aria-hidden={true}
-        className="icon icon--dropdown"
-        focusable={false}
-        height="24px"
-        width="24px"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <use
-          xlinkHref="#icon-dropdown"
-        />
-      </svg>
-    </span>
+    </svg>
   </button>
   <div
     className="fake-menu-button__menu fake-menu"


### PR DESCRIPTION
- Add `split` prop (will be used by EbaySplitButton component)
- Improve expand-button feature, add more stories
- Improve readme

Storybook: https://opensource.ebay.com/ebayui-core-react/ebay-button-split/index.html?path=/story/ebay-button--split-button