### PR TITLE
Added id prop to EbayPageNotice

### DIFF
--- a/src/ebay-page-notice/README.md
+++ b/src/ebay-page-notice/README.md
@@ -49,3 +49,5 @@ import "@ebay/skin/page-notice";
 | `children`   | React Node                                                                    | No       | The content to be displayed within the notice                                                                                               | -             |
 | `a11yDismissText` | String                                                                   | No       | Determines if the notice will have a dismiss button.  Acts as the aria-label for the dismiss button. Should not be used with a footer.      | -             |
 | `onDismissed` | Dispatch<boolean>                                                            | No       | Handler for any extra functionality for after a notice is dismissed.                                                                        | -             |
+
+Note: When using multiple PageNotice components with an aria-label, make sure to set a unique `id` attribute for each one or you'll run into accessibility issues.

--- a/src/ebay-page-notice/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-page-notice/__tests__/__snapshots__/index.spec.tsx.snap
@@ -358,3 +358,37 @@ exports[`Storyshots ebay-page-notice Simple usage 1`] = `
   </section>
 </DocumentFragment>
 `;
+
+exports[`Storyshots ebay-page-notice Simple usage with id 1`] = `
+<DocumentFragment>
+  <section
+    aria-labelledby="main-page-notice"
+    class="page-notice page-notice--confirmation"
+    role="region"
+  >
+    <div
+      class="page-notice__header"
+      id="main-page-notice"
+    >
+      <svg
+        aria-label="Success"
+        class="icon icon--confirmation-filled-small"
+        focusable="false"
+        height="16px"
+        role="img"
+        width="16px"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-confirmation-filled-small"
+        />
+      </svg>
+    </div>
+    <div
+      class="page-notice__main"
+    >
+      text message
+    </div>
+  </section>
+</DocumentFragment>
+`;

--- a/src/ebay-page-notice/__tests__/index.stories.tsx
+++ b/src/ebay-page-notice/__tests__/index.stories.tsx
@@ -10,6 +10,12 @@ storiesOf(`ebay-page-notice`, module)
         </EbayPageNotice>
     </>))
 
+    .add(`Simple usage with id`, () => (<>
+        <EbayPageNotice status="confirmation" aria-label="Success" id="main-page-notice">
+            <EbayNoticeContent>text message</EbayNoticeContent>
+        </EbayPageNotice>
+    </>))
+
     .add(`Confirmation message`, () => (<>
         <EbayPageNotice status="confirmation" aria-label="Success">
             <EbayNoticeContent>

--- a/src/ebay-page-notice/page-notice.tsx
+++ b/src/ebay-page-notice/page-notice.tsx
@@ -11,6 +11,7 @@ type Props = React.HTMLProps<HTMLElement> & {
 };
 
 const EbayPageNotice: FC<Props> = ({
+    id,
     status = 'general',
     children,
     onDismiss,
@@ -36,11 +37,11 @@ const EbayPageNotice: FC<Props> = ({
     return dismissed ? null : (
         <section
             {...rest}
-            aria-labelledby={`${status}-status`}
+            aria-labelledby={id || `${status}-status`}
             className={`page-notice ${status !== `general` ? `page-notice--${status}` : ``}`}
             role="region">
             {status !== `general` ? (
-                <div className="page-notice__header" id={`${status}-status`}>
+                <div className="page-notice__header" id={id || `${status}-status`}>
                     <EbayIcon
                         name={`${status}FilledSmall` as Icon}
                         a11yText={ariaLabel}


### PR DESCRIPTION
Moved to branch instead of fork.

Accessibility Team filed a bug for the below issue.
> **Expected Result**
The value assigned to an id attribute used in ARIA or in form labels must be unique to prevent the second instance from being overlooked by assistive technology.
> **Actual Result**
Document has multiple elements referenced with ARIA with the same id attribute: attention-status

Some eBay applications use multiple of these EbayPageNotice with the same status, so the ids end up being the same. So, to fix this without breaking other applications, I added an optional override to that key.