### PR TITLE
[Fix] Pagination show-last variant overflow button click disabled

### DIFF
--- a/src/ebay-pagination/pagination-item.tsx
+++ b/src/ebay-pagination/pagination-item.tsx
@@ -3,14 +3,12 @@ import { EbayIcon } from '../ebay-icon'
 import { withForwardRef } from '../common/component-utils'
 import classNames from 'classnames'
 
-export type PaginationItemType = 'previous' | 'next' | 'page'
-export type RoleItemType = 'separator'
+export type PaginationItemType = 'previous' | 'next' | 'page' | 'separator'
 type HtmlProps = Omit<ComponentProps<'button'>, 'type' | 'role'> & ComponentProps<'a'> & ComponentProps<'li'>
 export type PaginationItemProps = HtmlProps & {
     pageIndex?: number;
     key?: Key;
     type?: PaginationItemType;
-    role?: RoleItemType;
     current?: boolean;
     disabled?: boolean;
     href?: string;
@@ -31,7 +29,6 @@ const EbayPaginationItem: FC<PaginationItemProps> = ({
     current,
     disabled,
     type = 'page',
-    role,
     href,
     hide,
     children,
@@ -61,21 +58,8 @@ const EbayPaginationItem: FC<PaginationItemProps> = ({
         }
     }
     const isAnchor = !!href
-    const isSeparator = role === 'separator'
     const ButtonOrAnchor = isAnchor ? 'a' : 'button'
     const iconClassName = isAnchor ? 'icon-link' : 'icon-btn'
-    if (isSeparator) {
-        return (
-            <span
-                key={key}
-                style={style}
-                className="pagination__item"
-                ref={forwardedRef}
-                role="separator">
-                {children}
-            </span>
-        )
-    }
     switch (type) {
         case 'previous':
             return (
@@ -106,6 +90,17 @@ const EbayPaginationItem: FC<PaginationItemProps> = ({
                 >
                     <EbayIcon name="paginationNext" />
                 </ButtonOrAnchor >
+            )
+        case 'separator':
+            return (
+                <span
+                    key={key}
+                    style={style}
+                    className="pagination__item"
+                    ref={forwardedRef}
+                    role="separator">
+                    {children}
+                </span>
             )
         default:
             return (

--- a/src/ebay-pagination/pagination-item.tsx
+++ b/src/ebay-pagination/pagination-item.tsx
@@ -4,11 +4,13 @@ import { withForwardRef } from '../common/component-utils'
 import classNames from 'classnames'
 
 export type PaginationItemType = 'previous' | 'next' | 'page'
-type HtmlProps = Omit<ComponentProps<'button'>, 'type'> & ComponentProps<'a'> & ComponentProps<'li'>
+export type RoleItemType = 'separator'
+type HtmlProps = Omit<ComponentProps<'button'>, 'type' | 'role'> & ComponentProps<'a'> & ComponentProps<'li'>
 export type PaginationItemProps = HtmlProps & {
     pageIndex?: number;
     key?: Key;
     type?: PaginationItemType;
+    role?: RoleItemType;
     current?: boolean;
     disabled?: boolean;
     href?: string;
@@ -29,6 +31,7 @@ const EbayPaginationItem: FC<PaginationItemProps> = ({
     current,
     disabled,
     type = 'page',
+    role,
     href,
     hide,
     children,
@@ -58,8 +61,21 @@ const EbayPaginationItem: FC<PaginationItemProps> = ({
         }
     }
     const isAnchor = !!href
+    const isSeparator = role === 'separator'
     const ButtonOrAnchor = isAnchor ? 'a' : 'button'
     const iconClassName = isAnchor ? 'icon-link' : 'icon-btn'
+    if (isSeparator) {
+        return (
+            <span
+                key={key}
+                style={style}
+                className="pagination__item"
+                ref={forwardedRef}
+                role="separator">
+                {children}
+            </span>
+        )
+    }
     switch (type) {
         case 'previous':
             return (

--- a/src/ebay-pagination/pagination-item.tsx
+++ b/src/ebay-pagination/pagination-item.tsx
@@ -4,7 +4,7 @@ import { withForwardRef } from '../common/component-utils'
 import classNames from 'classnames'
 
 export type PaginationItemType = 'previous' | 'next' | 'page' | 'separator'
-type HtmlProps = Omit<ComponentProps<'button'>, 'type' | 'role'> & ComponentProps<'a'> & ComponentProps<'li'>
+type HtmlProps = Omit<ComponentProps<'button'>, 'type'> & ComponentProps<'a'> & ComponentProps<'li'>
 export type PaginationItemProps = HtmlProps & {
     pageIndex?: number;
     key?: Key;

--- a/src/ebay-pagination/pagination.tsx
+++ b/src/ebay-pagination/pagination.tsx
@@ -108,7 +108,7 @@ const EbayPagination: FC<PaginationProps> = ({
                 role: isDot ? 'separator' : undefined,
                 key,
                 hide,
-                onPrevious, onSelect, onNext, a11yPreviousText, a11yNextText,
+                onPrevious, onNext, onSelect, a11yPreviousText, a11yNextText,
                 ref: childPageRefs.current[index]
             }
             // include hidden numbers & number of (...)itself

--- a/src/ebay-pagination/pagination.tsx
+++ b/src/ebay-pagination/pagination.tsx
@@ -101,11 +101,12 @@ const EbayPagination: FC<PaginationProps> = ({
             const isDot = page[index] === 'dots'
             const key = `${id}-item-${index}`
             const hide = page[index] === 'hidden'
+            const isSeparator = isDot && type === 'page'
             const newProps = {
-                type, current, disabled, href,
+                current, disabled, href,
+                type: isSeparator ? 'separator' : type,
                 children: isDot ? <EbayIcon name="overflow" height="18px" focusable={false} /> : text,
                 pageIndex: type === 'page' ? pageIndex++ : undefined,
-                role: isDot ? 'separator' : undefined,
                 key,
                 hide,
                 onPrevious, onNext, onSelect, a11yPreviousText, a11yNextText,

--- a/src/ebay-pagination/pagination.tsx
+++ b/src/ebay-pagination/pagination.tsx
@@ -12,6 +12,7 @@ import { calcPageState, getMaxWidth } from './helpers'
 import { filterBy } from '../common/component-utils'
 import { PaginationItemType } from './pagination-item'
 import { ItemState, PaginationVariant } from './types'
+import { EbayIcon } from '../ebay-icon'
 
 type PaginationCallback = (e?: Event, value?: string) => void;
 type PaginationProps = Omit<ComponentProps<'nav'>, 'onSelect'> & {
@@ -100,15 +101,14 @@ const EbayPagination: FC<PaginationProps> = ({
             const isDot = page[index] === 'dots'
             const key = `${id}-item-${index}`
             const hide = page[index] === 'hidden'
-            const disableSelect = isDot && variant === 'show-last'
             const newProps = {
                 type, current, disabled, href,
-                children: isDot ? '…' : text,
+                children: isDot ? <EbayIcon name="overflow" height="18px" focusable={false} /> : text,
                 pageIndex: type === 'page' ? pageIndex++ : undefined,
-                onSelect: disableSelect ? undefined : onSelect,
+                role: isDot ? 'separator' : undefined,
                 key,
                 hide,
-                onPrevious, onNext, a11yPreviousText, a11yNextText,
+                onPrevious, onSelect, onNext, a11yPreviousText, a11yNextText,
                 ref: childPageRefs.current[index]
             }
             // include hidden numbers & number of (...)itself

--- a/src/ebay-pagination/pagination.tsx
+++ b/src/ebay-pagination/pagination.tsx
@@ -100,13 +100,15 @@ const EbayPagination: FC<PaginationProps> = ({
             const isDot = page[index] === 'dots'
             const key = `${id}-item-${index}`
             const hide = page[index] === 'hidden'
+            const disableSelect = isDot && variant === 'show-last'
             const newProps = {
                 type, current, disabled, href,
                 children: isDot ? '…' : text,
                 pageIndex: type === 'page' ? pageIndex++ : undefined,
+                onSelect: disableSelect ? undefined : onSelect,
                 key,
                 hide,
-                onPrevious, onNext, onSelect, a11yPreviousText, a11yNextText,
+                onPrevious, onNext, a11yPreviousText, a11yNextText,
                 ref: childPageRefs.current[index]
             }
             // include hidden numbers & number of (...)itself


### PR DESCRIPTION
- Fix on dots not clickable for "show-last" variation

Storybook: https://opensource.ebay.com/ebayui-core-react/pagination-clickable-overflow-fix/index.html?path=/story/ebay-pagination--variant-showlast-interactive