### PR TITLE
EbayMenu: Improve callbacks

### DIFF
--- a/src/common/event-utils/index.ts
+++ b/src/common/event-utils/index.ts
@@ -2,6 +2,7 @@
 * Based on https://github.com/eBay/ebayui-core/edit/master/src/common/event-utils/index.js
 */
 
+import React from 'react'
 import { Key } from './types'
 
 type Callback = () => void
@@ -12,41 +13,49 @@ type Callback = () => void
  * @param {KeyboardEvent} e
  * @param {Function} callback
  */
-function handleKeydown(keyList: Key[], e: KeyboardEvent, callback: Callback = () => {}): void {
+function handleKeydown(keyList: Key[], e: React.KeyboardEvent, callback: Callback = () => {}): void {
     if (keyList.includes(e.key as Key)) {
         callback()
     }
 }
 
 // inverse of found keys
-function handleNotKeydown(keyList: Key[], e: KeyboardEvent, callback: Callback = () => {}): void {
+function handleNotKeydown(keyList: Key[], e: React.KeyboardEvent, callback: Callback = () => {}): void {
     if (!keyList.includes(e.key as Key)) {
         callback()
     }
 }
 
-export function handleEnterKeydown(e: KeyboardEvent, callback: Callback): void {
-    handleKeydown(['Enter'], e, callback)
+export function handleEnterKeydown(e: React.KeyboardEvent, callback: Callback): void {
+    if (e.key === 'Enter') {
+        callback()
+    }
 }
 
-export function handleActionKeydown(e: KeyboardEvent, callback: Callback): void {
-    handleKeydown([' ', 'Enter'], e, callback)
+export function handleActionKeydown(e: React.KeyboardEvent, callback: Callback): void {
+    if (isActionKey(e.key as Key)) {
+        callback()
+    }
 }
 
-export function handleEscapeKeydown(e: KeyboardEvent, callback: Callback): void {
+export function isActionKey(key: Key): boolean {
+    return [' ', 'Enter'].includes(key)
+}
+
+export function handleEscapeKeydown(e: React.KeyboardEvent, callback: Callback): void {
     handleKeydown(['Esc', 'Escape'], e, callback)
 }
 
-export function handleUpDownArrowsKeydown(e: KeyboardEvent, callback: Callback): void {
+export function handleUpDownArrowsKeydown(e: React.KeyboardEvent, callback: Callback): void {
     handleKeydown(['Up', 'ArrowUp', 'Down', 'ArrowDown'], e, callback)
 }
 
-export function handleLeftRightArrowsKeydown(e: KeyboardEvent, callback: Callback): void {
+export function handleLeftRightArrowsKeydown(e: React.KeyboardEvent, callback: Callback): void {
     handleKeydown(['Left', 'ArrowLeft', 'Right', 'ArrowRight'], e, callback)
 }
 
 // only fire for character input, not modifier/meta keys (enter, escape, backspace, tab, etc.)
-export function handleTextInput(e: KeyboardEvent, callback: Callback): void {
+export function handleTextInput(e: React.KeyboardEvent, callback: Callback): void {
     const keyList: Key[] = [
         // Edge
         'Esc',
@@ -72,7 +81,7 @@ export function handleTextInput(e: KeyboardEvent, callback: Callback): void {
     handleNotKeydown(keyList, e, callback)
 }
 
-export function preventDefaultIfHijax(e: KeyboardEvent, hijax: boolean): void {
+export function preventDefaultIfHijax(e: React.KeyboardEvent, hijax: boolean): void {
     if (hijax) {
         e.preventDefault()
     }

--- a/src/common/event-utils/types.ts
+++ b/src/common/event-utils/types.ts
@@ -1,3 +1,5 @@
+import { ChangeEvent, KeyboardEvent, MouseEvent, FocusEvent, SyntheticEvent } from 'react'
+
 type ModifierKeys = 'Alt' | 'AltGraph' | 'Control' | 'Shift' | 'CapsLock' | 'Meta'
 // | 'Fn' | 'FnLock' | 'Hyper' | 'NumLock' | 'ScrollLock' | 'Super' | 'Symbol' | 'SymbolLock'
 type NavigationKeys = 'ArrowDown' | 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'Enter' | 'Tab' | ' ' | 'Escape'
@@ -9,3 +11,28 @@ type NavigationKeysEdge = 'Down' | 'Left' | 'Right' | 'Up' | 'Esc'
 // 'Separator' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9'
 
 export type Key = ModifierKeys | NavigationKeys | NavigationKeysEdge
+
+type BaseEventHandler<E extends SyntheticEvent<any>, P> = (event: E, props?: P) => void;
+
+export type EbayEventHandler<ElementType = Element, PropsObject = Record<string, any>> =
+    BaseEventHandler<SyntheticEvent<ElementType>, PropsObject>;
+export type EbayMouseEventHandler<ElementType = Element, PropsObject = Record<string, any>> =
+    BaseEventHandler<MouseEvent<ElementType>, PropsObject>;
+export type EbayKeyboardEventHandler<ElementType = Element, PropsObject = Record<string, any>> =
+    BaseEventHandler<KeyboardEvent<ElementType>, PropsObject>;
+export type EbayChangeEventHandler<ElementType = Element, PropsObject = Record<string, any>> =
+    BaseEventHandler<ChangeEvent<ElementType>, PropsObject>;
+export type EbayFocusEventHandler<ElementType = Element, PropsObject = Record<string, any>> =
+    BaseEventHandler<FocusEvent<ElementType>, PropsObject>;
+/*
+    type ClipboardEventHandler<T = Element> = EventHandler<ClipboardEvent<T>>;
+    type CompositionEventHandler<T = Element> = EventHandler<CompositionEvent<T>>;
+    type DragEventHandler<T = Element> = EventHandler<DragEvent<T>>;
+    type FormEventHandler<T = Element> = EventHandler<FormEvent<T>>;
+    type TouchEventHandler<T = Element> = EventHandler<TouchEvent<T>>;
+    type PointerEventHandler<T = Element> = EventHandler<PointerEvent<T>>;
+    type UIEventHandler<T = Element> = EventHandler<UIEvent<T>>;
+    type WheelEventHandler<T = Element> = EventHandler<WheelEvent<T>>;
+    type AnimationEventHandler<T = Element> = EventHandler<AnimationEvent<T>>;
+    type TransitionEventHandler<T = Element> = EventHandler<TransitionEvent<T>>;
+*/

--- a/src/ebay-menu/README.md
+++ b/src/ebay-menu/README.md
@@ -26,15 +26,15 @@ Name | Type | Required | Description
 --- | --- | --- | ---
 `type` | String | No | Can be `radio`/`checkbox`
 `checked` | Number | No | when used with `radio` type will check the item with the corresponding index
-`onKeydown` | Function | No | arguments: (index: number, checked: boolean)
-`onChange` | Function | No | arguments: (index: number, checked: boolean) for type `radio`/`checkbox`
-`onSelect` | Function | No | arguments: (index: number, checked: boolean), not for use with type `radio`/`checkbox`
+`onKeydown` | Function | No | props: (e: event, { index: number, checked: number[], checkedValues?: string[] })
+`onSelect` | Function | No | props: (e: event, { index: number }), triggered on item clicked (not for type `radio`/`checkbox`)
+`onChange` | Function | No | props: (e: event, { index: number, checked: number[], checkedValues: string[]), triggered on item `checked` change, (for type `radio`/`checkbox` only)
 
 ## EbayMenuItem Props
 
 Name | Type | Required | Description
 --- | --- | --- | ---
-`value` | String | No | for type `radio`, `checkbox`: the value to use with callbacks for `checked[]`
+`value` | String | No | for type `radio`, `checkbox`: the value to use with callbacks for `checkedValues[]`
 `checked` | Boolean | No | for type `radio`, `checkbox`: whether or not the item is checked
 `disabled` | Boolean | No | makes the menu item disabled
 `badgeNumber` | Number | No | used as the number to be placed in the badge

--- a/src/ebay-menu/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-menu/__tests__/__snapshots__/index.spec.tsx.snap
@@ -34,6 +34,7 @@ exports[`Storyshots ebay-menu Checkbox 1`] = `
         </svg>
       </div>
       <div
+        aria-checked="false"
         aria-hidden="false"
         class="menu__item"
         role="menuitem"
@@ -170,87 +171,324 @@ exports[`Storyshots ebay-menu Default 1`] = `
 
 exports[`Storyshots ebay-menu Radio 1`] = `
 <DocumentFragment>
-  <span
-    class="menu"
+  <div
+    class="tabs"
   >
     <div
-      class="menu__items"
-      role="menu"
+      class="tabs__items"
+      role="tablist"
     >
       <div
-        aria-checked="true"
-        aria-hidden="false"
-        class="menu__item"
-        role="menuitem"
+        aria-controls="default-tabpanel-0"
+        aria-selected="true"
+        class="tabs__item"
+        id="default-tab-0"
+        role="tab"
         tabindex="0"
-        value="item 1"
       >
         <span>
-          item 1
+          Menu.checked
         </span>
-        <svg
-          aria-hidden="true"
-          class="icon icon--tick-small"
-          focusable="false"
-          height="16px"
-          width="16px"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <use
-            xlink:href="#icon-tick-small"
-          />
-        </svg>
       </div>
       <div
-        aria-checked="false"
-        aria-hidden="false"
-        class="menu__item"
-        role="menuitem"
-        tabindex="0"
-        value="item 2"
+        aria-controls="default-tabpanel-1"
+        aria-selected="false"
+        class="tabs__item"
+        id="default-tab-1"
+        role="tab"
+        tabindex="-1"
       >
         <span>
-          item 2
+          Item.checked
         </span>
-        <svg
-          aria-hidden="true"
-          class="icon icon--tick-small"
-          focusable="false"
-          height="16px"
-          width="16px"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <use
-            xlink:href="#icon-tick-small"
-          />
-        </svg>
       </div>
       <div
-        aria-checked="false"
-        aria-hidden="false"
-        class="menu__item"
-        role="menuitem"
-        tabindex="0"
-        value="item 3"
+        aria-controls="default-tabpanel-2"
+        aria-selected="false"
+        class="tabs__item"
+        id="default-tab-2"
+        role="tab"
+        tabindex="-1"
       >
         <span>
-          item 3
+          Menu.checked+Item.checked
         </span>
-        <svg
-          aria-hidden="true"
-          class="icon icon--tick-small"
-          focusable="false"
-          height="16px"
-          width="16px"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <use
-            xlink:href="#icon-tick-small"
-          />
-        </svg>
       </div>
     </div>
-  </span>
+    <div
+      class="tabs__content"
+    >
+      <div
+        aria-labelledby="default-tab-0"
+        class="tabs__panel"
+        id="default-tabpanel-0"
+        role="tabpanel"
+      >
+        <div
+          class="tabs__cell"
+        >
+          <span
+            class="menu"
+          >
+            <div
+              class="menu__items"
+              role="menu"
+            >
+              <div
+                aria-checked="false"
+                aria-hidden="false"
+                class="menu__item"
+                role="menuitem"
+                tabindex="0"
+              >
+                <span>
+                  item 0
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="icon icon--tick-small"
+                  focusable="false"
+                  height="16px"
+                  width="16px"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="#icon-tick-small"
+                  />
+                </svg>
+              </div>
+              <div
+                aria-checked="true"
+                aria-hidden="false"
+                class="menu__item"
+                role="menuitem"
+                tabindex="0"
+              >
+                <span>
+                  Prechecked on menu level
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="icon icon--tick-small"
+                  focusable="false"
+                  height="16px"
+                  width="16px"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="#icon-tick-small"
+                  />
+                </svg>
+              </div>
+              <div
+                aria-checked="false"
+                aria-hidden="false"
+                class="menu__item"
+                role="menuitem"
+                tabindex="0"
+              >
+                <span>
+                  item 2
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="icon icon--tick-small"
+                  focusable="false"
+                  height="16px"
+                  width="16px"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="#icon-tick-small"
+                  />
+                </svg>
+              </div>
+            </div>
+          </span>
+        </div>
+      </div>
+      <div
+        aria-labelledby="default-tab-1"
+        class="tabs__panel"
+        hidden=""
+        id="default-tabpanel-1"
+        role="tabpanel"
+      >
+        <div
+          class="tabs__cell"
+        >
+          <span
+            class="menu"
+          >
+            <div
+              class="menu__items"
+              role="menu"
+            >
+              <div
+                aria-checked="true"
+                aria-hidden="false"
+                class="menu__item"
+                role="menuitem"
+                tabindex="0"
+              >
+                <span>
+                  Prechecked on item level
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="icon icon--tick-small"
+                  focusable="false"
+                  height="16px"
+                  width="16px"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="#icon-tick-small"
+                  />
+                </svg>
+              </div>
+              <div
+                aria-checked="false"
+                aria-hidden="false"
+                class="menu__item"
+                role="menuitem"
+                tabindex="0"
+              >
+                <span>
+                  item 1
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="icon icon--tick-small"
+                  focusable="false"
+                  height="16px"
+                  width="16px"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="#icon-tick-small"
+                  />
+                </svg>
+              </div>
+              <div
+                aria-checked="false"
+                aria-hidden="false"
+                class="menu__item"
+                role="menuitem"
+                tabindex="0"
+              >
+                <span>
+                  item 2
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="icon icon--tick-small"
+                  focusable="false"
+                  height="16px"
+                  width="16px"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="#icon-tick-small"
+                  />
+                </svg>
+              </div>
+            </div>
+          </span>
+        </div>
+      </div>
+      <div
+        aria-labelledby="default-tab-2"
+        class="tabs__panel"
+        hidden=""
+        id="default-tabpanel-2"
+        role="tabpanel"
+      >
+        <div
+          class="tabs__cell"
+        >
+          <span
+            class="menu"
+          >
+            <div
+              class="menu__items"
+              role="menu"
+            >
+              <div
+                aria-checked="false"
+                aria-hidden="false"
+                class="menu__item"
+                role="menuitem"
+                tabindex="0"
+              >
+                <span>
+                  Prechecked on item level
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="icon icon--tick-small"
+                  focusable="false"
+                  height="16px"
+                  width="16px"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="#icon-tick-small"
+                  />
+                </svg>
+              </div>
+              <div
+                aria-checked="true"
+                aria-hidden="false"
+                class="menu__item"
+                role="menuitem"
+                tabindex="0"
+              >
+                <span>
+                  Prechecked on menu level
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="icon icon--tick-small"
+                  focusable="false"
+                  height="16px"
+                  width="16px"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="#icon-tick-small"
+                  />
+                </svg>
+              </div>
+              <div
+                aria-checked="false"
+                aria-hidden="false"
+                class="menu__item"
+                role="menuitem"
+                tabindex="0"
+              >
+                <span>
+                  item 2
+                </span>
+                <svg
+                  aria-hidden="true"
+                  class="icon icon--tick-small"
+                  focusable="false"
+                  height="16px"
+                  width="16px"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <use
+                    xlink:href="#icon-tick-small"
+                  />
+                </svg>
+              </div>
+            </div>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
 </DocumentFragment>
 `;
 

--- a/src/ebay-menu/__tests__/index.spec.tsx
+++ b/src/ebay-menu/__tests__/index.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
+import { act } from '@testing-library/react-hooks'
 import { initStoryshots } from '../../../config/jest/storyshots'
 import { EbayMenu, EbayMenuItem } from '../index'
 
@@ -7,81 +8,230 @@ initStoryshots({
     config: ({ configure }) => configure(() => require('./index.stories'), module)
 })
 
+const onKeyDownSpy = jest.fn()
+const onClickSpy = jest.fn()
+const onSelectSpy = jest.fn()
+const onChangeSpy = jest.fn()
+
 describe('<EbayMenu>', () => {
-    describe('on menu item click', () => {
-        it('should fire onClick event', () => {
-            const onClickSpy = jest.fn()
-            const wrapper = render(
-                <EbayMenu>
-                    <EbayMenuItem onClick={onClickSpy}/>
+    describe('menu item', () => {
+        beforeEach(() => {
+            render(
+                <EbayMenu onClick={onClickSpy} onSelect={onSelectSpy} onKeyDown={onKeyDownSpy}>
+                    <EbayMenuItem value="1">item1</EbayMenuItem>
+                    <EbayMenuItem value="2">item2</EbayMenuItem>
                 </EbayMenu>
             )
+        })
 
-            fireEvent.click(wrapper.container.querySelector('.menu__item'))
+        it('should fire onClick, onSelect event', async () => {
+            await act(() => {
+                fireEvent.click(screen.getByText('item2'))
+            })
 
-            expect(onClickSpy).toBeCalled()
+            const expectedProps = {
+                index: 1,
+                checked: [1]
+            }
+
+            expect(onClickSpy).toBeCalledWith(expect.any(Object))
+            expect(onSelectSpy).toBeCalledWith(expect.any(Object), expectedProps)
+        })
+
+        it('should fire onKeyDown event', async () => {
+            const [item1] = screen.getAllByRole('menuitem')
+
+            await act(() => {
+                fireEvent.keyDown(item1, { key: 'Esc' })
+            })
+
+            const expectedProps = {
+                index: 0,
+                checked: []
+            }
+
+            expect(onKeyDownSpy).toBeCalledWith(expect.any(Object), expectedProps)
+        })
+
+        it('should fire onKeyDown, onSelect event', async () => {
+            const [item1, item2] = screen.getAllByRole('menuitem')
+
+            await act(() => {
+                fireEvent.keyDown(item2, { key: 'Enter' })
+            })
+
+            const expectedProps = {
+                index: 1,
+                checked: [1]
+            }
+
+            expect(onKeyDownSpy).toBeCalledWith(expect.any(Object), expectedProps)
+            expect(onSelectSpy).toBeCalledWith(expect.any(Object), expectedProps)
         })
     })
-    describe('on key down', () => {
-        it('should fire onKeyDown event', () => {
-            const onKeyDownSpy = jest.fn()
-            const wrapper = render(
-                <EbayMenu onKeyDown={onKeyDownSpy}>
-                    <EbayMenuItem/>
+
+    describe('type="radio"', () => {
+        beforeEach(() => {
+            render(
+                <EbayMenu
+                    type="radio"
+                    onClick={onClickSpy}
+                    onChange={onChangeSpy}
+                    onKeyDown={onKeyDownSpy}
+                >
+                    <EbayMenuItem value="1" checked>item1</EbayMenuItem>
+                    <EbayMenuItem value="2">item2</EbayMenuItem>
                 </EbayMenu>
             )
-            fireEvent.keyDown(wrapper.container.querySelector('.menu__item'))
+        })
+        it('should fire onClick, onChange event', async () => {
+            const [item1, item2] = screen.getAllByRole('menuitem')
 
-            expect(onKeyDownSpy).toBeCalledWith(0, false)
+            expect(item1).toHaveAttribute('aria-checked', 'true')
+            expect(item2).toHaveAttribute('aria-checked', 'false')
+
+            await act(() => {
+                fireEvent.click(item2)
+            })
+
+            const expectedProps = {
+                index: 1,
+                indexes: [1],
+                checked: [1],
+                checkedValues: ['2']
+            }
+
+            expect(onClickSpy).toBeCalledWith(expect.any(Object))
+            expect(onChangeSpy).toBeCalledWith(expect.any(Object), expectedProps)
+
+            expect(item1).toHaveAttribute('aria-checked', 'false')
+            expect(item2).toHaveAttribute('aria-checked', 'true')
+        })
+
+        it('should fire onKeyDown event', async () => {
+            const [item1] = screen.getAllByRole('menuitem')
+
+            await act(() => {
+                fireEvent.keyDown(item1, { key: 'Esc' })
+            })
+
+            const expectedProps = {
+                index: 0,
+                indexes: [0],
+                checked: [0],
+                checkedValues: ['1']
+            }
+
+            expect(onKeyDownSpy).toBeCalledWith(expect.any(Object), expectedProps)
+        })
+
+        it('should fire onKeyDown, onChange event', async () => {
+            const [item1, item2] = screen.getAllByRole('menuitem')
+
+            await act(() => {
+                fireEvent.keyDown(item2, { key: 'Enter' })
+            })
+
+            const expectedProps = {
+                index: 1,
+                indexes: [1],
+                checked: [1],
+                checkedValues: ['2']
+            }
+
+            expect(onKeyDownSpy).toBeCalledWith(expect.any(Object), expectedProps)
+            expect(onChangeSpy).toBeCalledWith(expect.any(Object), expectedProps)
         })
     })
-    describe('on radio item select', () => {
-        it('should fire onSelect & onChange event', () => {
-            const onSelectSpy = jest.fn()
-            const onChangeSpy = jest.fn()
-            const wrapper = render(
-                <EbayMenu onSelect={onSelectSpy} onChange={onChangeSpy} type='radio'>
-                    <EbayMenuItem checked />
-                    <EbayMenuItem />
+
+    describe('type="checkbox"', () => {
+        beforeEach(() => {
+            render(
+                <EbayMenu
+                    type="checkbox"
+                    onClick={onClickSpy}
+                    onChange={onChangeSpy}
+                    onKeyDown={onKeyDownSpy}
+                >
+                    <EbayMenuItem value="1" checked>item1</EbayMenuItem>
+                    <EbayMenuItem value="2">item2</EbayMenuItem>
                 </EbayMenu>
             )
-            expect(wrapper.container.querySelector('.menu__item')).toHaveAttribute('aria-checked', 'true')
-            expect(wrapper.container.querySelectorAll('.menu__item')[1]).toHaveAttribute('aria-checked', 'false')
-
-            fireEvent.click(wrapper.container.querySelectorAll('.menu__item')[1])
-
-            expect(onChangeSpy).toBeCalledWith(1, true)
-            expect(onSelectSpy).toBeCalledWith(1, true)
-
-            expect(wrapper.container.querySelector('.menu__item')).toHaveAttribute('aria-checked', 'false')
-            expect(wrapper.container.querySelectorAll('.menu__item')[1]).toHaveAttribute('aria-checked', 'true')
         })
-    })
-    describe('on checkbox item select', () => {
-        it('should fire onSelect & onChange event', () => {
-            const onSelectSpy = jest.fn()
-            const onChangeSpy = jest.fn()
-            const wrapper = render(
-                <EbayMenu onSelect={onSelectSpy} onChange={onChangeSpy} type='checkbox'>
-                    <EbayMenuItem />
-                    <EbayMenuItem checked />
-                </EbayMenu>
-            )
-            expect(wrapper.container.querySelector('.menu__item')).not.toHaveAttribute('aria-checked')
-            expect(wrapper.container.querySelectorAll('.menu__item')[1]).toHaveAttribute('aria-checked', 'true')
+        it('should fire onClick, onChange event', async () => {
+            const [item1, item2] = screen.getAllByRole('menuitem')
 
-            fireEvent.click(wrapper.container.querySelectorAll('.menu__item')[1])
+            expect(item1).toHaveAttribute('aria-checked', 'true')
+            expect(item2).toHaveAttribute('aria-checked', 'false')
 
-            expect(onChangeSpy).toBeCalledWith(1, false)
-            expect(onSelectSpy).toBeCalledWith(1, false)
+            await act(() => {
+                fireEvent.click(item2)
+            })
 
-            expect(wrapper.container.querySelector('.menu__item')).not.toHaveAttribute('aria-checked')
-            expect(wrapper.container.querySelectorAll('.menu__item')[1]).toHaveAttribute('aria-checked', 'false')
+            let expectedProps = {
+                index: 1,
+                indexes: [0, 1],
+                checked: [0, 1],
+                checkedValues: ['1', '2']
+            }
 
-            fireEvent.click(wrapper.container.querySelectorAll('.menu__item')[0])
+            expect(onClickSpy).toBeCalledWith(expect.any(Object))
+            expect(onChangeSpy).toBeCalledWith(expect.any(Object), expectedProps)
 
-            expect(wrapper.container.querySelector('.menu__item')).toHaveAttribute('aria-checked', 'true')
-            expect(wrapper.container.querySelectorAll('.menu__item')[1]).toHaveAttribute('aria-checked', 'false')
+            expect(item1).toHaveAttribute('aria-checked', 'true')
+            expect(item2).toHaveAttribute('aria-checked', 'true')
+
+            await act(() => {
+                fireEvent.click(item1)
+            })
+
+            expectedProps = {
+                index: 0,
+                indexes: [1],
+                checked: [1],
+                checkedValues: ['2']
+            }
+
+            expect(onClickSpy).toBeCalledWith(expect.any(Object))
+            expect(onChangeSpy).toBeCalledWith(expect.any(Object), expectedProps)
+
+            expect(item1).toHaveAttribute('aria-checked', 'false')
+            expect(item2).toHaveAttribute('aria-checked', 'true')
+        })
+
+        it('should fire onKeyDown event', async () => {
+            const [item1] = screen.getAllByRole('menuitem')
+
+            await act(() => {
+                fireEvent.keyDown(item1, { key: 'Esc' })
+            })
+
+            const expectedProps = {
+                index: 0,
+                indexes: [0],
+                checked: [0],
+                checkedValues: ['1']
+            }
+
+            expect(onKeyDownSpy).toBeCalledWith(expect.any(Object), expectedProps)
+        })
+
+        it('should fire onKeyDown, onChange event', async () => {
+            const [item1, item2] = screen.getAllByRole('menuitem')
+
+            await act(() => {
+                fireEvent.keyDown(item2, { key: ' ' })
+            })
+
+            const expectedProps = {
+                index: 1,
+                indexes: [0, 1],
+                checked: [0, 1],
+                checkedValues: ['1', '2']
+            }
+
+            expect(onKeyDownSpy).toBeCalledWith(expect.any(Object), expectedProps)
+            expect(onChangeSpy).toBeCalledWith(expect.any(Object), expectedProps)
         })
     })
 })

--- a/src/ebay-menu/__tests__/index.stories.tsx
+++ b/src/ebay-menu/__tests__/index.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react';
 import { action } from '../../../.storybook/action'
 import { EbayMenu, EbayMenuItem as Item, EbayMenuSeparator as Separator } from '../index'
-import { EbayIcon } from '../..'
+import { EbayIcon, EbayTab, EbayTabPanel, EbayTabs } from '../..'
 
 storiesOf('ebay-menu', module)
     .add('Default', () => (<>
@@ -16,16 +16,51 @@ storiesOf('ebay-menu', module)
         </EbayMenu>
     </>))
     .add('Radio', () => (<>
-        <EbayMenu
-            type="radio"
-            onKeyDown={action('key down')}
-            onChange={action('change')}
-            onSelect={action('select')}
-        >
-            <Item value="item 1" checked>item 1</Item>
-            <Item value="item 2">item 2</Item>
-            <Item value="item 3">item 3</Item>
-        </EbayMenu>
+        <EbayTabs>
+            <EbayTab>Menu.checked</EbayTab>
+            <EbayTabPanel>
+                <EbayMenu
+                    type="radio"
+                    checked={1}
+                    onKeyDown={action('key down')}
+                    onChange={action('change')}
+                    onSelect={action('select')}
+                >
+                    <Item>item 0</Item>
+                    <Item>Prechecked on menu level</Item>
+                    <Item>item 2</Item>
+                </EbayMenu>
+            </EbayTabPanel>
+
+            <EbayTab>Item.checked</EbayTab>
+            <EbayTabPanel>
+                <EbayMenu
+                    type="radio"
+                    onKeyDown={action('key down')}
+                    onChange={action('change')}
+                    onSelect={action('select')}
+                >
+                    <Item checked>Prechecked on item level</Item>
+                    <Item>item 1</Item>
+                    <Item>item 2</Item>
+                </EbayMenu>
+            </EbayTabPanel>
+
+            <EbayTab>Menu.checked+Item.checked</EbayTab>
+            <EbayTabPanel>
+                <EbayMenu
+                    type="radio"
+                    checked={1}
+                    onKeyDown={action('key down')}
+                    onChange={action('change')}
+                    onSelect={action('select')}
+                >
+                    <Item checked>Prechecked on item level</Item>
+                    <Item>Prechecked on menu level</Item>
+                    <Item>item 2</Item>
+                </EbayMenu>
+            </EbayTabPanel>
+        </EbayTabs>
     </>))
     .add('Checkbox', () => (<>
         <EbayMenu

--- a/src/ebay-menu/index.ts
+++ b/src/ebay-menu/index.ts
@@ -1,4 +1,4 @@
 export { default as EbayMenu } from './menu'
 export { default as EbayMenuItem, MenuItemProps } from './menu-item'
 export { default as EbayMenuSeparator } from './menu-item-separator'
-export { EbayMenuType, EbayMenuPriority } from './types'
+export * from './types'

--- a/src/ebay-menu/menu-item.tsx
+++ b/src/ebay-menu/menu-item.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import { EbayBadge } from '../ebay-badge'
 import { EbayIcon } from '../ebay-icon'
 
-export type MenuItemProps = Omit<ComponentProps<'div'>, 'onKeyDown'> & {
+export type MenuItemProps = ComponentProps<'div'> & {
     focused?: boolean;
     tabIndex?: number;
     checked?: boolean;

--- a/src/ebay-menu/menu.tsx
+++ b/src/ebay-menu/menu.tsx
@@ -1,98 +1,145 @@
 import React, {
-    Children, cloneElement, useEffect, useState,
-    ComponentProps, FC, ReactElement
+    Children,
+    cloneElement,
+    FC,
+    KeyboardEvent,
+    MouseEvent,
+    ReactElement,
+    useEffect,
+    useState
 } from 'react'
 import classNames from 'classnames'
 import useRovingIndex from '../common/event-utils/use-roving-index'
-import { usePrevious } from '../common/component-utils/usePrevious'
-import { handleActionKeydown } from '../common/event-utils'
-import { MenuItemProps } from './menu-item'
-import { EbayMenuItem, EbayMenuType, EbayMenuPriority } from './index'
+import { isActionKey } from '../common/event-utils'
+import { withForwardRef } from '../common/component-utils'
+import { EbayMenuItem, MenuItemProps, EbayMenuProps } from './index'
+import { Key } from '../common/event-utils/types'
 
-type SpanProps = Omit<ComponentProps<'span'>, 'onKeyDown' | 'onChange'>
-type Callback = (i: number, checked: boolean) => void
-type Props = SpanProps & {
-    type?: EbayMenuType;
-    priority?: EbayMenuPriority;
-    checked?: number;
-    onKeyDown?: Callback;
-    onSelect?: Callback;
-    onChange?: Callback;
-}
-
-const changedIndex = (arr1: boolean[], arr2: boolean[]): number => arr1.findIndex((x, i) => arr2[i] !== x)
-
-const EbayMenu: FC<Props> = ({
+const EbayMenu: FC<EbayMenuProps> = ({
     type,
     priority = 'secondary',
     checked,
     className,
+    autofocus,
+    onClick = () => {},
     onKeyDown = () => {},
     onChange = () => {},
     onSelect = () => {},
+    forwardedRef,
     children,
     ...rest
 }) => {
-    const childrenArray = Children.toArray(children)
-    const [focusedIndex, setFocusedIndex] = useRovingIndex(children, EbayMenuItem)
+    const childrenArray = Children.toArray(children) as ReactElement[]
+    const [focusedIndex, setFocusedIndex] = useRovingIndex(children, EbayMenuItem, autofocus === true ? 0 : undefined)
     const [checkedIndexes, setCheckedIndexes] = useState<boolean[]>(childrenArray.map(() => false))
 
-    const updateIndex = (index: number, value: boolean, resetOthers = false) => {
-        setCheckedIndexes(prevCheckedIndexes =>
-            prevCheckedIndexes.map((indexChecked, i) => {
-                const defaultValue = resetOthers ? false : indexChecked
-                return index === i ? value : defaultValue
-            }))
+    const valuesFromChecked = (indexes: boolean[]): string[] =>
+        childrenArray.reduce((values, item, i) =>
+            indexes[i] ? [...values, item.props.value] : values, [])
+
+    const indexesFromChecked = (indexes: boolean[]): number[] =>
+        indexes.reduce((all, value, i) => value ? [...all, i] : all, [])
+
+    const eventProps = (index: number, indexes: boolean[]) => ({
+        index,
+        checked: indexesFromChecked(indexes)
+    })
+    const checkboxEventProps = (index: number, indexes: boolean[]) => ({
+        ...eventProps(index, indexes),
+        indexes: indexesFromChecked(indexes),
+        checkedValues: valuesFromChecked(indexes)
+    })
+
+    const updateIndex = (index: number, value: boolean, resetOthers = false): boolean[] | void => {
+        let anyChanges = false
+        const newValues = checkedIndexes.map((indexChecked, i) => {
+            const defaultValue = resetOthers ? false : indexChecked
+            if (index === i) {
+                if (indexChecked !== value) {
+                    anyChanges = true
+                }
+                return value
+            }
+            return defaultValue
+        })
+        if (anyChanges) {
+            setCheckedIndexes(newValues)
+            return newValues
+        }
     }
-    const selectIndex = (index: number) => {
+    const selectIndex = (index: number): boolean[] | void => {
         switch (type) {
             case 'radio':
                 return updateIndex(index, true, true)
             case 'checkbox':
-                return updateIndex(index, !checkedIndexes[index])
+                return updateIndex(index, !checkedIndexes[index], false)
             default:
-                return
+                return checkedIndexes.map((_, i) => i === index)
         }
     }
 
     useEffect(() => {
         if (type === 'radio') {
-            if (checked !== undefined) {
+            if (checked === undefined) {
+                const checkedIndex = childrenArray.findIndex(child => child.props.checked)
+                if (checkedIndex > -1) {
+                    selectIndex(checkedIndex)
+                }
+            } else {
                 selectIndex(checked)
             }
-            const checkedIndex = childrenArray.findIndex((child: ReactElement) => child.props.checked)
-            if (checkedIndex > -1) {
-                selectIndex(checkedIndex)
-            }
         } else if (type === 'checkbox') {
-            setCheckedIndexes(childrenArray.map((child: ReactElement) => child.props.checked))
+            setCheckedIndexes(childrenArray.map(child => Boolean(child.props.checked)))
         }
     }, [])
 
-    const prevCheckedIndexes = usePrevious(checkedIndexes)
-    useEffect(() => {
-        if (type === 'radio') {
-            const checkedIndex = checkedIndexes.findIndex(Boolean)
-            if (checkedIndex > -1) {
-                onChange(checkedIndex, true)
-                onSelect(checkedIndex, true)
-            }
-        } else if (type === 'checkbox') {
-            if (prevCheckedIndexes) {
-                const index = changedIndex(prevCheckedIndexes, checkedIndexes)
-                onChange(index, checkedIndexes[index])
-                onSelect(index, checkedIndexes[index])
+    const handleChange = (
+        e: MouseEvent<HTMLElement> | KeyboardEvent<HTMLElement>,
+        index: number,
+        newValues: boolean[]
+    ) => {
+        switch (type) {
+            case 'radio':
+            case 'checkbox':
+                return onChange(e, checkboxEventProps(index, newValues))
+            default:
+                return onSelect(e, eventProps(index, newValues))
+        }
+    }
+
+    const handleKeyDown = (e: KeyboardEvent<HTMLElement>, index: number) => {
+        let newValues
+        if (isActionKey(e.key as Key)) {
+            newValues = selectIndex(index)
+            if (newValues) {
+                handleChange(e, index, newValues)
             }
         }
-    }, [checkedIndexes])
+        switch (type) {
+            case 'radio':
+            case 'checkbox':
+                return onKeyDown(e, checkboxEventProps(index, newValues || checkedIndexes))
+            default:
+                return onKeyDown(e, eventProps(index, newValues || checkedIndexes))
+        }
+    }
+
+    const handleClick = (e: MouseEvent<HTMLElement>, index: number) => {
+        setFocusedIndex(index)
+        const newValues = selectIndex(index)
+        if (newValues) {
+            handleChange(e, index, newValues)
+        }
+    }
 
     return (
         <span {...rest} className={classNames(className, 'menu')}>
-            <div className="menu__items" role="menu">
+            <div className="menu__items" role="menu" ref={forwardedRef}>
                 {childrenArray.map((child: ReactElement, i) => {
                     const {
-                        onClick = () => {},
-                        onFocus = () => {},
+                        onFocus: onItemFocus = () => {},
+                        onClick: onItemClick = () => {},
+                        onKeyDown: onItemKeyDown = () => {},
                         ...itemRest
                     }: MenuItemProps = child.props
 
@@ -103,18 +150,16 @@ const EbayMenu: FC<Props> = ({
                         checked: checkedIndexes[i],
                         onFocus: e => {
                             setFocusedIndex(i)
-                            onFocus(e)
+                            onItemFocus(e)
                         },
                         onClick: e => {
-                            setFocusedIndex(i)
-                            selectIndex(i)
+                            handleClick(e, i)
+                            onItemClick(e)
                             onClick(e)
                         },
                         onKeyDown: e => {
-                            handleActionKeydown(e, () => {
-                                selectIndex(i)
-                            })
-                            onKeyDown(i, checkedIndexes[i])
+                            handleKeyDown(e, i)
+                            onItemKeyDown(e)
                         }
                     } as MenuItemProps)
                 })}
@@ -123,4 +168,4 @@ const EbayMenu: FC<Props> = ({
     )
 }
 
-export default EbayMenu
+export default withForwardRef(EbayMenu)

--- a/src/ebay-menu/types.ts
+++ b/src/ebay-menu/types.ts
@@ -1,2 +1,28 @@
+import { ComponentProps, Ref } from 'react'
+import { EbayEventHandler, EbayKeyboardEventHandler } from '../common/event-utils/types'
+
 export type EbayMenuType = 'radio' | 'checkbox'
 export type EbayMenuPriority = 'primary' | 'secondary' | 'none'
+
+type SpanProps = Omit<ComponentProps<'span'>, 'onKeyDown' | 'onChange'>
+type SelectProps = {
+    index: number;
+    checked: number[];
+}
+type ChangeProps = SelectProps & {
+    indexes: number[];
+    checkedValues: string[];
+}
+export type EbayMenuKeyDownEventHandler = EbayKeyboardEventHandler<HTMLElement, SelectProps | ChangeProps>
+export type EbayMenuChangeEventHandler = EbayEventHandler<HTMLElement, ChangeProps>
+export type EbayMenuSelectEventHandler = EbayEventHandler<HTMLElement, SelectProps>
+export type EbayMenuProps = SpanProps & {
+    type?: EbayMenuType;
+    priority?: EbayMenuPriority;
+    checked?: number;
+    autofocus?: boolean;
+    onKeyDown?: EbayMenuKeyDownEventHandler;
+    onChange?: EbayMenuChangeEventHandler;
+    onSelect?: EbayMenuSelectEventHandler;
+    forwardedRef?: Ref<HTMLDivElement>;
+}

--- a/src/ebay-tabs/tabs.tsx
+++ b/src/ebay-tabs/tabs.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, ComponentProps, FC, useEffect, useState } from 'react'
+import React, { cloneElement, ComponentProps, FC, KeyboardEvent, useEffect, useState } from 'react'
 import classNames from 'classnames'
 
 import { handleActionKeydown, handleLeftRightArrowsKeydown } from '../common/event-utils'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@ export { EbayButton, EbayButtonCell, Size, Priority, EbayButtonProps } from './e
 export { EbayCtaButton } from './ebay-cta-button'
 export { EbayEek, EbayEekProps } from './ebay-eek'
 export { EbayIconButton, EbayIconButtonProps } from './ebay-icon-button'
-export { EbayMenu, EbayMenuItem, EbayMenuSeparator, EbayMenuType, EbayMenuPriority } from './ebay-menu'
+export {
+    EbayMenu, EbayMenuItem, EbayMenuSeparator,
+    EbayMenuType, EbayMenuPriority, EbayMenuProps, MenuItemProps,
+    EbayMenuChangeEventHandler, EbayMenuSelectEventHandler, EbayMenuKeyDownEventHandler
+} from './ebay-menu'
 export { EbayFakeMenu, EbayFakeMenuItem, EbayFakeMenuSeparator, EbayFakeMenuItemProps } from './ebay-fake-menu'
 export {
     EbayFakeMenuButton, EbayFakeMenuButtonProps,


### PR DESCRIPTION
- Implements #171 for EbayMenu
- Add callback tests
- Add story actions to see those callbacks
- Follow marko API

I'm making this PR against `improved-callbacks` branch, cause those callbacks are incompatible with old ones and will break the code that uses them. We'll bump major version when we merge that branch.

storybook: https://opensource.ebay.com/ebayui-core-react/EbayMenu-callbacks/index.html?path=/story/ebay-menu--default