### PR TITLE
[FEAT] EbayListboxButton: Adding missing tabIndex functionality from marko component

### DIFF
--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -61,6 +61,8 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     const [expanded, setExpanded] = useState(false)
     // Additional flag to avoid multiple re-render when users tries to open and close
     const [optionsOpened, setOptionsOpened] = useState(false)
+    // variable tabIndex
+    const [listContainerTabIndex, setListContainerTabIndex] = useState(-1)
 
     useEffect(() => {
         setSelectedOption(selectedOptionFromValue)
@@ -80,6 +82,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
         setSelectedIndex(index)
         setExpanded(false)
         setActiveDescendant(index)
+        setListContainerTabIndex(0)
         buttonRef.current.focus()
         onSelect(e, optionValue, index)
     }
@@ -126,12 +129,18 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
         setSelectedOption(childrenArray[updatedIndex])
     }
 
-    const focusOptionsContainer = (focusOptions?: FocusOptions) =>
-        setTimeout(() => optionsContainerRef?.current?.focus(focusOptions), 0)
+    const focusOptionsContainer = (focusOptions?: FocusOptions) => {
+        setListContainerTabIndex(0)
+        return setTimeout(() => optionsContainerRef?.current?.focus(focusOptions), 0)
+    }
     const onButtonClick = () => {
         setExpanded(!expanded)
         setOptionsOpened(true)
         focusOptionsContainer({ preventScroll: true })
+        // setting the tabIndex attribute depending on the expanded state of the list, 0 when opened, -1 when closed
+        if (expanded) {
+            setListContainerTabIndex(-1)
+        }
     }
     const onButtonKeyup = (e: KeyboardEvent<HTMLButtonElement>) => {
         switch (e.key as Key) {
@@ -235,7 +244,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
                     <div
                         className="listbox-button__options"
                         role="listbox"
-                        tabIndex={0}
+                        tabIndex={listContainerTabIndex}
                         ref={optionsContainerRef}
                         onKeyDown={(e) => onOptionContainerKeydown(e)}
                         // adding onMouseDown preventDefault b/c on IE the onClick event is not being fired on each

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -61,8 +61,6 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     const [expanded, setExpanded] = useState(false)
     // Additional flag to avoid multiple re-render when users tries to open and close
     const [optionsOpened, setOptionsOpened] = useState(false)
-    // variable tabIndex
-    const [listContainerTabIndex, setListContainerTabIndex] = useState(-1)
 
     useEffect(() => {
         setSelectedOption(selectedOptionFromValue)
@@ -129,18 +127,13 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
         setSelectedOption(childrenArray[updatedIndex])
     }
 
-    const focusOptionsContainer = (focusOptions?: FocusOptions) => {
-        setListContainerTabIndex(0)
-        return setTimeout(() => optionsContainerRef?.current?.focus(focusOptions), 0)
-    }
+    const focusOptionsContainer = (focusOptions?: FocusOptions) =>
+        setTimeout(() => optionsContainerRef?.current?.focus(focusOptions), 0)
+    
     const onButtonClick = () => {
         setExpanded(!expanded)
         setOptionsOpened(true)
         focusOptionsContainer({ preventScroll: true })
-        // setting the tabIndex attribute depending on the expanded state of the list, 0 when opened, -1 when closed
-        if (expanded) {
-            setListContainerTabIndex(-1)
-        }
     }
     const onButtonKeyup = (e: KeyboardEvent<HTMLButtonElement>) => {
         switch (e.key as Key) {
@@ -244,7 +237,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
                     <div
                         className="listbox-button__options"
                         role="listbox"
-                        tabIndex={listContainerTabIndex}
+                        tabIndex={expanded ? 0 : -1}
                         ref={optionsContainerRef}
                         onKeyDown={(e) => onOptionContainerKeydown(e)}
                         // adding onMouseDown preventDefault b/c on IE the onClick event is not being fired on each

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -80,7 +80,6 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
         setSelectedIndex(index)
         setExpanded(false)
         setActiveDescendant(index)
-        setListContainerTabIndex(0)
         buttonRef.current.focus()
         onSelect(e, optionValue, index)
     }


### PR DESCRIPTION
Adding missing functionality to have dynamic `tabIndex` with value `0`when list is open and `-1` when it is closed.
https://github.com/eBay/ebayui-core/blob/master/src/components/ebay-listbox/index.marko#:~:text=tabindex%3D(option.disabled%20%3F%20%2D1%20%3A%20option.tabindex)