### PR TITLE
FIX: Add missing types on components for React 18

### DIFF
--- a/src/common/notice-utils/notice-content.tsx
+++ b/src/common/notice-utils/notice-content.tsx
@@ -1,13 +1,13 @@
 import React, { FC, ReactNode } from 'react'
 import cx from 'classnames'
 
-type Props = {
+export type NoticeContentProps = {
     type: 'inline' | 'section' | 'page';
     className?: string;
     children?: ReactNode;
 }
 
-const NoticeContent: FC<Props> = ({ className, type, children }) => {
+const NoticeContent: FC<NoticeContentProps> = ({ className, type, children }) => {
     const ContentTag = type === 'inline' ? 'span' : 'div'
     return (
         <ContentTag className={cx(className, `${type}-notice__main`)}>

--- a/src/common/tooltip-utils/tooltip-content.tsx
+++ b/src/common/tooltip-utils/tooltip-content.tsx
@@ -6,7 +6,7 @@ import { DEFAULT_POINTER_DIRECTION, POINTER_STYLES } from './constants'
 import TooltipCloseButton from './tooltip-close-button'
 import TooltipFooter from './tooltip-footer'
 
-type TooltipContentProps = {
+export type TooltipContentProps = {
     id?: string;
     type?: TooltipType;
     style?: CSSProperties;

--- a/src/common/tooltip-utils/tooltip-host.tsx
+++ b/src/common/tooltip-utils/tooltip-host.tsx
@@ -1,13 +1,13 @@
 import { Children, cloneElement, FC, ReactElement, RefObject } from 'react'
 import classNames from 'classnames'
 
-type Props = {
+export type TooltipHostProps = {
     className?: string;
-    children: ReactElement;
+    children?: ReactElement;
     forwardedRef?: RefObject<any>;
 }
 
-const TooltipHost: FC<Props> = ({
+const TooltipHost: FC<TooltipHostProps> = ({
     children,
     className,
     forwardedRef,

--- a/src/ebay-infotip/ebay-infotip-content.tsx
+++ b/src/ebay-infotip/ebay-infotip-content.tsx
@@ -2,12 +2,9 @@
  * This Component is used only for finding it as a child of EbayInfotip
  * and pass the properties to TooltipContent
 */
-import React, { FC, ReactNode } from 'react'
+import React, { FC } from 'react'
+import { TooltipContentProps } from '../common/tooltip-utils/tooltip-content'
 
-type EbayInfotipContentProps = {
-    children?: ReactNode;
-}
-
-const EbayInfotipContent: FC = ({ children }: EbayInfotipContentProps) => <>{children}</>
+const EbayInfotipContent: FC<TooltipContentProps> = ({ children }) => <>{children}</>
 
 export default EbayInfotipContent

--- a/src/ebay-notice-base/components/ebay-notice-content/notice-content.tsx
+++ b/src/ebay-notice-base/components/ebay-notice-content/notice-content.tsx
@@ -3,7 +3,10 @@
  * and pass the properties to NoticeContent
  */
 import { FC } from 'react'
+import { NoticeContentProps } from '../../../common/notice-utils/notice-content'
 
-const EbayNoticeContent: FC = () => null
+type Props = Omit<NoticeContentProps, 'type'>
+
+const EbayNoticeContent: FC<Props> = () => null
 
 export default EbayNoticeContent

--- a/src/ebay-tooltip/ebay-tooltip-content.tsx
+++ b/src/ebay-tooltip/ebay-tooltip-content.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react'
+import { TooltipContentProps } from '../common/tooltip-utils/tooltip-content'
 
 /**
  * This Component is used only for finding it as a child of EbayTooltip
  * and pass the properties to TooltipContent
 */
 
-const EbayTooltipContent: FC = () => null
+const EbayTooltipContent: FC<TooltipContentProps> = () => null
 
 export default EbayTooltipContent

--- a/src/ebay-tooltip/ebay-tooltip-host.tsx
+++ b/src/ebay-tooltip/ebay-tooltip-host.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react'
+import { TooltipHostProps } from '../common/tooltip-utils/tooltip-host'
 
 /**
  * This Component is used only for finding it as a child of EbayTooltip
  * and pass the properties to TooltipHost
 */
 
-const EbayTooltipHost: FC = () => null
+const EbayTooltipHost: FC<TooltipHostProps> = () => null
 
 export default EbayTooltipHost

--- a/src/ebay-tourtip/ebay-tourtip-content.tsx
+++ b/src/ebay-tourtip/ebay-tourtip-content.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react'
+import { TooltipContentProps } from '../common/tooltip-utils/tooltip-content'
 
 /**
  * This Component is used only for finding it as a child of EbayTooltip
  * and pass the properties to TourtipContent
 */
 
-const EbayTourtipContent: FC = () => null
+const EbayTourtipContent: FC<TooltipContentProps> = () => null
 
 export default EbayTourtipContent

--- a/src/ebay-tourtip/ebay-tourtip-host.tsx
+++ b/src/ebay-tourtip/ebay-tourtip-host.tsx
@@ -1,10 +1,11 @@
 import { FC } from 'react'
+import { TooltipHostProps } from '../common/tooltip-utils/tooltip-host'
 
 /**
  * This Component is used only for finding it as a child of EbayTooltip
  * and pass the properties to TourtipHost
 */
 
-const EbayTourtipHost: FC = () => null
+const EbayTourtipHost: FC<TooltipHostProps> = () => null
 
 export default EbayTourtipHost


### PR DESCRIPTION
- Define props for components that are used only for extracting props on runtime (NoticeContent, TooltipHost, TooltipContent)

This is because for React 18 `children` prop is required to be defined when used with children in the application.