### PR TITLE
Adding missing functionality from marko component

### DIFF
--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -235,7 +235,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
                     <div
                         className="listbox-button__options"
                         role="listbox"
-                        tabIndex={0}
+                        tabIndex={expanded ? 0 : -1}
                         ref={optionsContainerRef}
                         onKeyDown={(e) => onOptionContainerKeydown(e)}
                         // adding onMouseDown preventDefault b/c on IE the onClick event is not being fired on each


### PR DESCRIPTION
This fix adds  missing functionality from marko component which changes the value of the tabIndex attribute, which by changing it we help a11y to prevent focusing into the list when it should be closed. 