### PR TITLE
Remove usage of global imports

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { jsxDecorator as withJsx } from 'storybook-addon-jsx'
 import { withA11y } from '@storybook/addon-a11y'
 import { withKnobs } from '@storybook/addon-knobs'
-import { EbaySvg } from '../src'
+import { EbaySvg } from '../src/ebay-svg'
 
 import "@ebay/skin"
 import "@ebay/skin/tokens"

--- a/src/ebay-alert-dialog/__tests__/index.spec.tsx
+++ b/src/ebay-alert-dialog/__tests__/index.spec.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
 import requireContext from 'node-require-context'
-import { render, RenderResult } from '@testing-library/react'
-import { EbayDialogHeader } from '../..'
+import { fireEvent, render, RenderResult } from '@testing-library/react'
 import { EbayAlertDialog } from '../index';
 import { initStoryshots } from '../../../config/jest/storyshots'
-import { fireEvent } from '@testing-library/react';
+import { EbayDialogHeader } from '../../ebay-dialog-base'
 
 jest.mock('../../common/random-id', () => ({ randomId: () => 'abc123' }))
 

--- a/src/ebay-alert-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-alert-dialog/__tests__/index.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
-import { EbayDialogHeader } from '../..'
-import {EbayAlertDialog} from "../index";
+import { EbayAlertDialog } from '../index';
+import { EbayDialogHeader } from '../../ebay-dialog-base'
 
 const story: any = {
     component: EbayAlertDialog,

--- a/src/ebay-badge/__tests__/index.spec.tsx
+++ b/src/ebay-badge/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { EbayBadge } from '../../index'
+import { EbayBadge } from '../index'
 import {render} from '@testing-library/react';
 
 describe('<EbayBadge>', () => {

--- a/src/ebay-badge/__tests__/index.stories.tsx
+++ b/src/ebay-badge/__tests__/index.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { EbayBadge } from '../../index'
+import { EbayBadge } from '../index'
 
 
 export default {

--- a/src/ebay-breadcrumbs/__tests__/index.spec.tsx
+++ b/src/ebay-breadcrumbs/__tests__/index.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import { initStoryshots } from '../../../config/jest/storyshots'
 
-import { EbayBreadcrumbs, EbayBreadcrumbItem } from '../../index'
+import { EbayBreadcrumbs, EbayBreadcrumbItem } from '../index'
 
 describe('<EbayBreadcrumbs>', () => {
     describe('on category click', () => {

--- a/src/ebay-breadcrumbs/__tests__/index.stories.tsx
+++ b/src/ebay-breadcrumbs/__tests__/index.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
 
-import { EbayBreadcrumbs, EbayBreadcrumbItem as Item } from '../../index'
+import { EbayBreadcrumbs, EbayBreadcrumbItem as Item } from '../index'
 
 storiesOf('ebay-breadcrumb', module)
     .add('default', () => (<>

--- a/src/ebay-button/__tests__/index.spec.tsx
+++ b/src/ebay-button/__tests__/index.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react';
 import { initStoryshots } from '../../../config/jest/storyshots'
-import { EbayButton } from '../../index'
+import { EbayButton } from '../index'
 
 initStoryshots({
     config: ({ configure }) =>

--- a/src/ebay-button/__tests__/index.stories.tsx
+++ b/src/ebay-button/__tests__/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
-import { EbayButton, EbayButtonCell } from '../../index'
+import { EbayButton, EbayButtonCell } from '../index'
 import EbayIcon from '../../ebay-icon/icon';
 
 storiesOf(`ebay-button`, module)

--- a/src/ebay-carousel/__tests__/index.spec.tsx
+++ b/src/ebay-carousel/__tests__/index.spec.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import requireContext from 'node-require-context'
+import { render, screen, cleanup } from '@testing-library/react';
 import { initStoryshots } from '../../../config/jest/storyshots'
-import { EbayCarouselItem, EbayCarousel } from "../index";
-import { render, screen, cleanup } from "@testing-library/react";
+import { EbayCarouselItem, EbayCarousel } from '../index';
 
 // NOTE: need to mock scrollTo since JSDOM does not support it
 jest.mock('../scroll-to-transition')

--- a/src/ebay-carousel/__tests__/index.stories.tsx
+++ b/src/ebay-carousel/__tests__/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import {EbayCarousel, EbayCarouselItem} from "../index";
-import {ComponentMeta } from "@storybook/react";
+import { ComponentMeta } from '@storybook/react';
+import { EbayCarousel, EbayCarouselItem } from '../index';
 
 const story: ComponentMeta<typeof EbayCarousel> = {
   component: EbayCarousel,

--- a/src/ebay-checkbox/__tests__/index.spec.tsx
+++ b/src/ebay-checkbox/__tests__/index.spec.tsx
@@ -3,13 +3,13 @@ import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { initStoryshots } from '../../../config/jest/storyshots'
-import { EbayCheckbox } from '../../index'
+import { EbayCheckbox } from '../index'
 
 describe('<EbayCheckbox>', () => {
     describe('on checkbox-button click', () => {
         it('should fire an event', () => {
             const spy = jest.fn()
-            const { getByLabelText, debug } = render(
+            const { getByLabelText } = render(
                 <EbayCheckbox aria-label="checkbox" onChange={spy} />
             )
             const input = getByLabelText('checkbox')

--- a/src/ebay-checkbox/__tests__/index.stories.tsx
+++ b/src/ebay-checkbox/__tests__/index.stories.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useRef, ReactElement, ChangeEvent } from 'react';
+import React, { useState, useRef, ChangeEvent } from 'react';
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
-import { EbayCheckbox, EbayLabel } from '../../index'
+import { EbayLabel } from '../../ebay-field'
+import { EbayCheckbox } from '../index'
 
 storiesOf(`ebay-checkbox`, module)
     .add(`Default checkbox-button`, () => (
@@ -105,9 +106,6 @@ storiesOf(`ebay-checkbox`, module)
                 }
                 counter.current++
             }
-            const label = isDisabled ?
-                <>Disabled</> :
-                <>Gets disabled after {5 - counter.current} clicks</>
 
             return (
                 <EbayCheckbox

--- a/src/ebay-confirm-dialog/__tests__/index.spec.tsx
+++ b/src/ebay-confirm-dialog/__tests__/index.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import requireContext from 'node-require-context'
 import { render, fireEvent, RenderResult } from '@testing-library/react'
-import { EbayDialogHeader } from '../..'
-import { EbayConfirmDialog } from '../index';
 import { initStoryshots } from '../../../config/jest/storyshots';
+import { EbayDialogHeader } from '../../ebay-dialog-base'
+import { EbayConfirmDialog } from '../index';
 
 jest.mock('../../common/random-id', () => ({ randomId: () => 'abc123' }))
 

--- a/src/ebay-confirm-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-confirm-dialog/__tests__/index.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
-import { EbayDialogHeader } from '../..'
-import {EbayConfirmDialog} from "../index";
+import { EbayConfirmDialog } from '../index';
+import { EbayDialogHeader } from '../../ebay-dialog-base'
 
 const story: any = {
     component: EbayConfirmDialog,

--- a/src/ebay-cta-button/__tests__/index.spec.tsx
+++ b/src/ebay-cta-button/__tests__/index.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { initStoryshots } from '../../../config/jest/storyshots'
-import { EbayCtaButton } from '../../index'
+import { EbayCtaButton } from '../index'
 
 initStoryshots({
     config: ({ configure }) =>

--- a/src/ebay-cta-button/__tests__/index.stories.tsx
+++ b/src/ebay-cta-button/__tests__/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { EbayCtaButton } from '../../index'
+import { EbayCtaButton } from '../index'
 
 storiesOf(`ebay-cta-button`, module)
     .add(`Default`, () => (

--- a/src/ebay-drawer-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-drawer-dialog/__tests__/index.stories.tsx
@@ -1,7 +1,8 @@
 import React, { createRef, useState } from 'react';
 import { EbayButton } from '../../ebay-button';
-import { EbayDrawerDialog, EbayDialogHeader, EbayDialogFooter } from '../../index';
 import { action } from '../../../.storybook/action';
+import { EbayDialogFooter, EbayDialogHeader } from '../../ebay-dialog-base'
+import { EbayDrawerDialog } from '../index';
 
 const story: any = {
     component: EbayDrawerDialog,

--- a/src/ebay-fake-menu-button/__tests__/index.stories.tsx
+++ b/src/ebay-fake-menu-button/__tests__/index.stories.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
+import { EbayIcon } from '../../ebay-icon'
 import {
     EbayFakeMenuButton,
     EbayFakeMenuButtonItem as Item,
     EbayFakeMenuButtonSeparator as Separator,
-    EbayFakeMenuButtonLabel,
-    EbayIcon
-} from '../../index'
+    EbayFakeMenuButtonLabel
+} from '../index'
 
 storiesOf('ebay-fake-menu-button', module)
     .add('Default', () => (<>

--- a/src/ebay-field/__tests__/index.stories.tsx
+++ b/src/ebay-field/__tests__/index.stories.tsx
@@ -1,13 +1,9 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import {
-    EbaySwitch,
-    EbayCheckbox,
-    EbayTextbox,
-    EbayField,
-    EbayLabel,
-    EbayFieldDescription
-} from '../../index'
+import { EbayTextbox } from '../../ebay-textbox'
+import { EbaySwitch } from '../../ebay-switch'
+import { EbayCheckbox } from '../../ebay-checkbox'
+import { EbayField, EbayLabel, EbayFieldDescription } from '../index'
 
 storiesOf(`ebay-field`, module)
 

--- a/src/ebay-fullscreen-dialog/__tests__/index.spec.tsx
+++ b/src/ebay-fullscreen-dialog/__tests__/index.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import requireContext from 'node-require-context'
 import { render, fireEvent } from '@testing-library/react'
-import { EbayDialogHeader, EbayFullscreenDialog } from '../..'
 import { initStoryshots } from '../../../config/jest/storyshots'
+import { EbayDialogHeader } from '../../ebay-dialog-base'
+import { EbayFullscreenDialog } from '../index'
 
 jest.mock('../../common/random-id', () => ({ randomId: () => 'abc123' }))
 

--- a/src/ebay-fullscreen-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-fullscreen-dialog/__tests__/index.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
-import { EbayDialogHeader, EbayDialogFooter, EbayFullscreenDialog } from '../..'
+import { EbayFullscreenDialog } from '../index'
+import { EbayDialogFooter, EbayDialogHeader } from '../../ebay-dialog-base'
 
 const story: any = {
   component: EbayFullscreenDialog,

--- a/src/ebay-icon-button/__tests__/index.stories.tsx
+++ b/src/ebay-icon-button/__tests__/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
-import { EbayIconButton } from '../../index'
+import { EbayIconButton } from '../index'
 
 storiesOf(`ebay-icon-button`, module)
     .add(`Default`, () => (

--- a/src/ebay-icon/__tests__/index.stories.tsx
+++ b/src/ebay-icon/__tests__/index.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Meta } from '@storybook/react'
-import { EbayIcon } from '../../index'
+import { EbayIcon } from '../index'
 import { icons } from './constants'
 
 export default {

--- a/src/ebay-infotip/__tests__/index.spec.tsx
+++ b/src/ebay-infotip/__tests__/index.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, fireEvent, RenderResult } from '@testing-library/react'
 import { initStoryshots } from '../../../config/jest/storyshots'
-import { EbayInfotip, EbayInfotipContent, EbayInfotipHeading } from '../../index'
+import { EbayInfotip, EbayInfotipContent, EbayInfotipHeading } from '../index'
 
 jest.mock('../../common/random-id', () => ({ randomId: () => 'abc123' }))
 

--- a/src/ebay-infotip/__tests__/index.stories.tsx
+++ b/src/ebay-infotip/__tests__/index.stories.tsx
@@ -6,7 +6,7 @@ import {
     EbayInfotipHeading,
     EbayInfotipHost,
     PointerDirection
-} from '../../index'
+} from '../index'
 
 const allPointers: PointerDirection[] = [
     `top`, `top-left`, `top-right`,

--- a/src/ebay-inline-notice/__tests__/index.spec.tsx
+++ b/src/ebay-inline-notice/__tests__/index.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { EbayInlineNotice, EbayNoticeContent } from '../../index'
+import { EbayInlineNotice, EbayNoticeContent } from '../index'
 import { initStoryshots } from '../../../config/jest/storyshots'
 
 describe('<EbayInlineNotice>', () => {

--- a/src/ebay-inline-notice/__tests__/index.stories.tsx
+++ b/src/ebay-inline-notice/__tests__/index.stories.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
-import { EbayButton, EbayInlineNotice, EbayNoticeContent } from '../../index'
+import { EbayButton } from '../../ebay-button'
+import { EbayInlineNotice, EbayNoticeContent } from '../index'
 
 storiesOf(`ebay-inline-notice`, module)
 

--- a/src/ebay-lightbox-dialog/__tests__/index.spec.tsx
+++ b/src/ebay-lightbox-dialog/__tests__/index.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import requireContext from 'node-require-context';
-import { EbayDialogFooter, EbayDialogHeader, EbayLightboxDialog } from '../..'
 import { initStoryshots } from '../../../config/jest/storyshots'
+import { EbayDialogFooter, EbayDialogHeader } from '../../ebay-dialog-base'
+import { EbayLightboxDialog } from '../index'
 
 jest.mock('../../common/random-id', () => ({ randomId: () => 'abc123' }))
 

--- a/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from 'react'
-import { EbayDialogHeader, EbayDialogFooter, EbayLightboxDialog, EbayButton, EbayCheckbox, EbayLabel } from '../..'
+import { EbayDialogFooter, EbayDialogHeader } from '../../ebay-dialog-base'
+import { EbayButton } from '../../ebay-button'
+import { EbayCheckbox } from '../../ebay-checkbox'
+import { EbayLabel } from '../../ebay-field'
+import { EbayLightboxDialog } from '../index'
 
 const story: any = {
     component: EbayLightboxDialog,

--- a/src/ebay-listbox-button/__tests__/index.stories.tsx
+++ b/src/ebay-listbox-button/__tests__/index.stories.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
 
-import { EbayListboxButton, EbayListboxButtonOption } from '../../index'
+import { EbayListboxButton, EbayListboxButtonOption } from '../index'
 import StateFullTest from './statefull-test'
 
 storiesOf(`ebay-listbox-button`, module)

--- a/src/ebay-listbox-button/__tests__/statefull-test.tsx
+++ b/src/ebay-listbox-button/__tests__/statefull-test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { EbayListboxButton, EbayListboxButtonOption } from '../../index'
+import { EbayListboxButton, EbayListboxButtonOption } from '../index'
 
 
 const StateFullTest = () => {

--- a/src/ebay-menu/__tests__/index.spec.tsx
+++ b/src/ebay-menu/__tests__/index.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { render, fireEvent, screen } from '@testing-library/react'
-import { act } from '@testing-library/react-hooks'
+import { render, fireEvent } from '@testing-library/react'
 import { initStoryshots } from '../../../config/jest/storyshots'
 import { EbayMenu, EbayMenuItem } from '../index'
 

--- a/src/ebay-menu/__tests__/index.spec.tsx
+++ b/src/ebay-menu/__tests__/index.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
+import { act } from '@testing-library/react-hooks'
 import { initStoryshots } from '../../../config/jest/storyshots'
 import { EbayMenu, EbayMenuItem } from '../index'
 

--- a/src/ebay-menu/__tests__/index.stories.tsx
+++ b/src/ebay-menu/__tests__/index.stories.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react';
 import { action } from '../../../.storybook/action'
+import { EbayIcon } from '../../ebay-icon'
 import { EbayMenu, EbayMenuItem as Item, EbayMenuSeparator as Separator } from '../index'
-import { EbayIcon } from '../..'
 
 storiesOf('ebay-menu', module)
     .add('Default', () => (<>

--- a/src/ebay-page-notice/__tests__/index.spec.tsx
+++ b/src/ebay-page-notice/__tests__/index.spec.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react'
-import { initStoryshots } from '../../../config/jest/storyshots';
-import { EbayNoticeContent, EbayPageNotice, EbayPageNoticeTitle } from '../';
 import userEvent from '@testing-library/user-event'
+import { initStoryshots } from '../../../config/jest/storyshots';
+import { EbayNoticeContent, EbayPageNotice, EbayPageNoticeTitle } from '../index';
 
 jest.mock('../../common/random-id', () => ({ randomId: () => 'abc123' }))
 
@@ -68,18 +68,18 @@ describe('<EbayPageNotice>', () => {
         })
 
         it( 'should hide the notice when the dismiss button is clicked.', async () => {
-            expect( wrapper.getByRole('region': {name:'Information'}) ).toBeVisible();
-            await dismissButton.click();
-            expect( wrapper.queryByRole('region': {name:'Information'}) ).toBeNull();
-            expect( dismissMock ).toHaveBeenCalled();
+            expect(wrapper.getByRole('region', { name: 'Information' })).toBeVisible()
+            await dismissButton.click()
+            expect(wrapper.queryByRole('region', { name: 'Information' })).toBeNull()
+            expect(dismissMock).toHaveBeenCalled()
         })
 
-        it( 'should hide the notice when the user focuses the dismiss button and presses space', async () => {
-            expect( wrapper.getByRole('region': {name:'Information'}) ).toBeVisible();
-            await dismissButton.focus();
-            userEvent.type( dismissButton, " " );
-            expect( wrapper.queryByRole('region': {name:'Information'}) ).toBeNull();
-            expect( dismissMock ).toHaveBeenCalled();
+        it('should hide the notice when the user focuses the dismiss button and presses space', async () => {
+            expect(wrapper.getByRole('region', { name: 'Information' })).toBeVisible()
+            await dismissButton.focus()
+            userEvent.type(dismissButton, ' ')
+            expect(wrapper.queryByRole('region', { name: 'Information' })).toBeNull()
+            expect(dismissMock).toHaveBeenCalled()
         })
     })
 })

--- a/src/ebay-panel-dialog/__tests__/index.spec.tsx
+++ b/src/ebay-panel-dialog/__tests__/index.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import requireContext from 'node-require-context'
 import { render, fireEvent } from '@testing-library/react'
-import { EbayDialogCloseButton, EbayDialogHeader, EbayPanelDialog } from '../..'
 import { initStoryshots } from '../../../config/jest/storyshots'
+import { EbayDialogCloseButton, EbayDialogHeader } from '../../ebay-dialog-base'
+import { EbayPanelDialog } from '../index'
 
 jest.mock('../../common/random-id', () => ({ randomId: () => 'abc123' }))
 

--- a/src/ebay-panel-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-panel-dialog/__tests__/index.stories.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
-import { EbayDialogHeader, EbayDialogCloseButton, EbayPanelDialog } from '../..'
+import { EbayPanelDialog } from '../index'
+import { EbayDialogCloseButton, EbayDialogHeader } from '../../ebay-dialog-base'
 
 const story: any = {
     component: EbayPanelDialog,

--- a/src/ebay-progress-stepper/__tests__/index.stories.tsx
+++ b/src/ebay-progress-stepper/__tests__/index.stories.tsx
@@ -1,13 +1,12 @@
 import React, { FC, useState } from 'react'
 import { storiesOf } from '@storybook/react'
-
+import { EbayButton } from '../../ebay-button'
 import {
     EbayProgressStepper,
     EbayProgressStep as Step,
     EbayProgressTitle as Title,
-    EbayButton,
     StepState
-} from '../../index'
+} from '../index'
 
 storiesOf(`ebay-progress-stepper`, module)
     .add(`Default`, () => (

--- a/src/ebay-radio/__tests__/index.spec.tsx
+++ b/src/ebay-radio/__tests__/index.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { initStoryshots } from '../../../config/jest/storyshots';
-import { EbayRadio } from '../../index';
+import { EbayRadio } from '../index';
 
 initStoryshots({
     config: ({ configure }) =>

--- a/src/ebay-radio/__tests__/index.stories.tsx
+++ b/src/ebay-radio/__tests__/index.stories.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
-import { EbayRadio, EbayButton, EbayLabel, EbayField } from '../../index'
+import { EbayField, EbayLabel } from '../../ebay-field'
+import { EbayButton } from '../../ebay-button'
+import { EbayRadio } from '../index'
 
 storiesOf(`ebay-radio`, module)
     .add(`Default`, () => (

--- a/src/ebay-section-notice/__tests__/index.spec.tsx
+++ b/src/ebay-section-notice/__tests__/index.spec.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { initStoryshots } from '../../../config/jest/storyshots';
-import { EbayButton, EbayNoticeContent, EbaySectionNotice } from '../../index';
+import { EbayButton } from '../../ebay-button'
+import { EbayNoticeContent, EbaySectionNotice } from '../index';
 
 describe('<EbaySectionNotice>', () => {
     describe('when a button is added in the children of the main section notice', () => {

--- a/src/ebay-section-notice/__tests__/index.stories.tsx
+++ b/src/ebay-section-notice/__tests__/index.stories.tsx
@@ -1,8 +1,8 @@
 import React  from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
-import { EbaySectionNotice, EbayButton, EbayNoticeContent } from '../../index'
-import { EbaySectionNoticeTitle, EbaySectionNoticeFooter } from '..'
+import { EbayButton } from '../../ebay-button'
+import { EbaySectionNotice, EbayNoticeContent, EbaySectionNoticeTitle, EbaySectionNoticeFooter } from '../index'
 
 storiesOf(`ebay-section-notice`, module)
 

--- a/src/ebay-section-title/__tests__/index.stories.tsx
+++ b/src/ebay-section-title/__tests__/index.stories.tsx
@@ -1,14 +1,12 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { EbayInfotip, EbayInfotipContent, EbayInfotipHeading } from '../../ebay-infotip'
 import {
     EbaySectionTitle,
     EbaySectionTitleTitle as Title,
     EbaySectionTitleSubtitle as Subtitle,
-    EbaySectionTitleInfo as Info,
-    EbayInfotip,
-    EbayInfotipContent,
-    EbayInfotipHeading
-} from '../../index'
+    EbaySectionTitleInfo as Info
+} from '../index'
 
 storiesOf('ebay-section-title', module)
     .add('Default', () => (

--- a/src/ebay-select/__tests__/index.spec.tsx
+++ b/src/ebay-select/__tests__/index.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react';
 import { initStoryshots } from '../../../config/jest/storyshots';
-import { EbaySelect, EbaySelectOption } from '../../index'
+import { EbaySelect, EbaySelectOption } from '../index'
 
 initStoryshots({
     config: ({ configure }) =>

--- a/src/ebay-select/__tests__/index.stories.tsx
+++ b/src/ebay-select/__tests__/index.stories.tsx
@@ -1,7 +1,8 @@
 import React, { ChangeEvent, useState } from 'react';
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
-import { EbaySelect, EbaySelectOption, EbayButton } from '../../index'
+import { EbayButton } from '../../ebay-button'
+import { EbaySelect, EbaySelectOption } from '../index'
 
 storiesOf(`ebay-select`, module)
     .add(`Basic`, () => (<>

--- a/src/ebay-signal/__tests__/index.spec.tsx
+++ b/src/ebay-signal/__tests__/index.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { EbaySignal, SignalStatus } from '../../index'
+import { EbaySignal, SignalStatus } from '../index'
 import { render } from '@testing-library/react';
 
 describe('<EbaySignal>', () => {

--- a/src/ebay-signal/__tests__/index.stories.tsx
+++ b/src/ebay-signal/__tests__/index.stories.tsx
@@ -1,9 +1,9 @@
-import React from "react";
-import { EbaySignal } from "../../index";
+import React from 'react';
+import { EbaySignal } from '../index';
 
 export default {
     component: EbaySignal,
-    title: "ebay-signal",
+    title: 'ebay-signal',
 };
 
 export const defaultCase = () => (<>

--- a/src/ebay-switch/__tests__/index.spec.tsx
+++ b/src/ebay-switch/__tests__/index.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
-import { EbaySwitch } from '../../index'
+import { EbaySwitch } from '../index'
 import { initStoryshots } from '../../../config/jest/storyshots'
 
 describe('<EbaySwitch>', () => {

--- a/src/ebay-switch/__tests__/index.stories.tsx
+++ b/src/ebay-switch/__tests__/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
-import { EbaySwitch } from '../../index'
+import { EbaySwitch } from '../index'
 
 storiesOf(`ebay-switch`, module)
     .add(`Default switch-button`, () => (

--- a/src/ebay-textbox/__tests__/index.spec.tsx
+++ b/src/ebay-textbox/__tests__/index.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
-import { fireEvent, render, waitFor } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { initStoryshots } from '../../../config/jest/storyshots'
-import { EbayTextbox, EbayTextboxPostfixIcon } from '../../index'
+import { EbayTextbox, EbayTextboxPostfixIcon } from '../index'
 
 describe('<EbayTextbox>', () => {
     describe('on textbox change', () => {

--- a/src/ebay-textbox/__tests__/index.stories.tsx
+++ b/src/ebay-textbox/__tests__/index.stories.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '../../../.storybook/action'
-import { EbayButton, EbayTextbox, EbayTextboxPostfixIcon, EbayTextboxPrefixIcon } from '../../index';
+import { EbayButton } from '../../ebay-button'
+import { EbayTextbox, EbayTextboxPostfixIcon, EbayTextboxPrefixIcon } from '../index';
 
 storiesOf('ebay-textbox', module)
     .add('Default textbox', () => (<>

--- a/src/ebay-tooltip/__tests__/index.spec.tsx
+++ b/src/ebay-tooltip/__tests__/index.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
-import { EbayTooltip, EbayTooltipContent, EbayTooltipHost } from '../../index'
+import { EbayTooltip, EbayTooltipContent, EbayTooltipHost } from '../index'
 import { initStoryshots } from '../../../config/jest/storyshots'
 
 jest.useFakeTimers()

--- a/src/ebay-tooltip/__tests__/index.stories.tsx
+++ b/src/ebay-tooltip/__tests__/index.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { EbayTooltip, EbayTooltipContent, EbayTooltipHost, EbayTextbox, EbayButton, PointerDirection } from '../../index'
+import { EbayButton } from '../../ebay-button'
+import { EbayTextbox } from '../../ebay-textbox'
+import { EbayTooltip, EbayTooltipContent, EbayTooltipHost, PointerDirection } from '../index'
 
 const allPointers: PointerDirection[] = [
     `top`, `top-left`, `top-right`,

--- a/src/ebay-tourtip/__tests__/index.spec.tsx
+++ b/src/ebay-tourtip/__tests__/index.spec.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { render, fireEvent, RenderResult } from '@testing-library/react'
 import { initStoryshots } from '../../../config/jest/storyshots'
-import { EbayButton, EbayTourtip, EbayTourtipContent, EbayTourtipFooter, EbayTourtipHeading, EbayTourtipHost } from '../../index'
+import { EbayButton } from '../../ebay-button'
+import { EbayTourtip, EbayTourtipContent, EbayTourtipFooter, EbayTourtipHeading, EbayTourtipHost } from '../index'
+
 
 const renderComponent = (props?: any) => render(
     <EbayTourtip a11yCloseText='close' pointer='bottom' {...props}>

--- a/src/ebay-tourtip/__tests__/index.stories.tsx
+++ b/src/ebay-tourtip/__tests__/index.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { EbayTourtip, EbayTourtipHeading , EbayTourtipContent, EbayTourtipHost, EbayButton, PointerDirection, EbayTourtipFooter } from '../../index'
+import { EbayButton } from '../../ebay-button'
+import { EbayTourtip, EbayTourtipHeading , EbayTourtipContent, EbayTourtipHost, PointerDirection, EbayTourtipFooter } from '../index'
 
 const allPointers: PointerDirection[] = [
     `top`, `top-left`, `top-right`,

--- a/src/ebay-video/__tests__/index.spec.tsx
+++ b/src/ebay-video/__tests__/index.spec.tsx
@@ -1,10 +1,10 @@
+import React from 'react'
 import requireContext from 'node-require-context'
+import { render, screen } from '@testing-library/react'
 import { initStoryshots } from '../../../config/jest/storyshots'
-import {EbayVideo, EbayVideoSource} from "../index";
-import React from "react";
-import {render, screen} from '@testing-library/react';
+import { EbayVideo, EbayVideoSource } from '../index'
 
-describe('<EbayVideo>' , () => {
+describe('<EbayVideo>', () => {
     beforeEach(() => render(<EbayVideo
         thumbnail="https://ir.ebaystatic.com/cr/v/c1/ebayui/video/v1/iphone-thumbnail.jpg"
         width={500}
@@ -21,11 +21,11 @@ describe('<EbayVideo>' , () => {
     it('shows video player with poster', () => {
         const video = document.getElementsByTagName('video')[0]
         expect(video).not.toBeNull()
-        expect(video.poster).toBe("https://ir.ebaystatic.com/cr/v/c1/ebayui/video/v1/iphone-thumbnail.jpg")
+        expect(video.poster).toBe('https://ir.ebaystatic.com/cr/v/c1/ebayui/video/v1/iphone-thumbnail.jpg')
     })
 
     it('shows error message', () => {
-        expect(screen.getByText("Error loading")).toBeInTheDocument()
+        expect(screen.getByText('Error loading')).toBeInTheDocument()
     })
 
     it('shows play button', () => {
@@ -39,7 +39,7 @@ describe('<EbayVideo>' , () => {
 
 initStoryshots({
     config: ({ configure }) => {
-        const req = requireContext('./', false, /\.stories\.tsx$/);
+        const req = requireContext('./', false, /\.stories\.tsx$/)
         return configure(req, module)
     }
-});
+})

--- a/src/ebay-video/__tests__/index.stories.tsx
+++ b/src/ebay-video/__tests__/index.stories.tsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react'
 import { Meta } from '@storybook/react'
 import 'shaka-player/dist/controls.css'
 
-import { EbayButton, EbayVideo, EbayVideoProps, EbayVideoSource } from '../../index'
 import { action } from '../../../.storybook/action'
+import { EbayButton } from '../../ebay-button'
+import { EbayVideo, EbayVideoProps, EbayVideoSource } from '../index'
 
 export default {
     component: EbayVideo,


### PR DESCRIPTION
Now it should be safe to remove global `index.ts` in next major release.

How I've tested:
- removed global index.ts
- yarn build
- yarn test
- yarn storybook
- 👍 