### PR TITLE
FIX: Remove tooltip role from infotip

### DIFF
--- a/src/common/tooltip-utils/constants.ts
+++ b/src/common/tooltip-utils/constants.ts
@@ -1,9 +1,15 @@
-import { PointerDirection } from './types'
+import { PointerDirection, TooltipType } from './types'
 
 export const DEFAULT_POINTER_DIRECTION: PointerDirection = 'bottom'
 
+export const TYPE_ROLES: Record<TooltipType, string> = {
+    tooltip: 'tooltip',
+    tourtip: 'region',
+    infotip: ''
+}
+
 export const POINTER_STYLES: { [key in PointerDirection]: any } = {
-    'left': {
+    left: {
         transform: 'translateX(16px) translateY(-50%) scale3d(1,1,1)',
         left: '100%',
         right: 'auto',
@@ -24,7 +30,7 @@ export const POINTER_STYLES: { [key in PointerDirection]: any } = {
         top: 'auto',
         bottom: '-10px'
     },
-    'right': {
+    right: {
         transform: 'translateX(-16px) translateY(-50%) scale3d(1,1,1)',
         left: 'auto',
         right: '100%',
@@ -45,7 +51,7 @@ export const POINTER_STYLES: { [key in PointerDirection]: any } = {
         top: 'auto',
         bottom: '-50%'
     },
-    'top': {
+    top: {
         transform: 'translateX(-50%) scale3d(1,1,1)',
         left: '50%',
         right: 'auto',
@@ -80,7 +86,7 @@ export const POINTER_STYLES: { [key in PointerDirection]: any } = {
         top: 'auto',
         bottom: 'calc(100% + 12px)'
     },
-    'bottom': {
+    bottom: {
         transform: 'translateX(-50%) scale3d(1,1,1)',
         left: '50%',
         right: 'auto',

--- a/src/common/tooltip-utils/tooltip-content.tsx
+++ b/src/common/tooltip-utils/tooltip-content.tsx
@@ -2,7 +2,7 @@ import React, { FC, CSSProperties, ReactNode } from 'react'
 import { EbayIcon } from '../../ebay-icon'
 import { excludeComponent, findComponent } from '../component-utils'
 import { PointerDirection, TooltipType } from './types'
-import { DEFAULT_POINTER_DIRECTION, POINTER_STYLES } from './constants'
+import { DEFAULT_POINTER_DIRECTION, POINTER_STYLES, TYPE_ROLES } from './constants'
 import TooltipCloseButton from './tooltip-close-button'
 import TooltipFooter from './tooltip-footer'
 
@@ -35,7 +35,7 @@ const TooltipContent: FC<TooltipContentProps> = ({
         <span
             className={`${type}__overlay`}
             id={id}
-            role="tooltip"
+            role={TYPE_ROLES[type] || null}
             style={{ ...POINTER_STYLES[pointer], ...style }}>
             <span className={`${type}__pointer ${type}__pointer--${pointer}`} />
             <span className={`${type}__mask`}>

--- a/src/ebay-infotip/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-infotip/__tests__/__snapshots__/index.spec.tsx.snap
@@ -39,7 +39,6 @@ exports[`Storyshots ebay-infotip Custom button content (With render prop) 1`] = 
       </button>
       <span
         class="infotip__overlay"
-        role="tooltip"
         style="transform: scale3d(1,1,1); left: -10px;"
       >
         <span
@@ -118,7 +117,6 @@ exports[`Storyshots ebay-infotip Custom icon 1`] = `
       </button>
       <span
         class="infotip__overlay"
-        role="tooltip"
         style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
       >
         <span
@@ -197,7 +195,6 @@ exports[`Storyshots ebay-infotip Default 1`] = `
       </button>
       <span
         class="infotip__overlay"
-        role="tooltip"
         style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
       >
         <span
@@ -277,7 +274,6 @@ exports[`Storyshots ebay-infotip Disabled 1`] = `
       </button>
       <span
         class="infotip__overlay"
-        role="tooltip"
         style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
       >
         <span
@@ -356,7 +352,6 @@ exports[`Storyshots ebay-infotip Expanded by default 1`] = `
       </button>
       <span
         class="infotip__overlay"
-        role="tooltip"
         style="transform: scale3d(1,1,1); left: -10px;"
       >
         <span
@@ -440,7 +435,6 @@ exports[`Storyshots ebay-infotip In paragraph 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
         >
           <span
@@ -614,7 +608,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
         >
           <span
@@ -689,7 +682,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: scale3d(1,1,1); left: -10px;"
         >
           <span
@@ -764,7 +756,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: scale3d(1,1,1); right: -10px;"
         >
           <span
@@ -839,7 +830,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: translateX(-16px) translateY(-50%) scale3d(1,1,1); right: 100%; top: -6px;"
         >
           <span
@@ -914,7 +904,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: translateX(-16px) scale3d(1,1,1); right: 100%; bottom: -50%;"
         >
           <span
@@ -989,7 +978,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: translateX(-16px) scale3d(1,1,1); right: 100%; top: -100%;"
         >
           <span
@@ -1064,7 +1052,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
         >
           <span
@@ -1139,7 +1126,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: scale3d(1,1,1); left: -10px;"
         >
           <span
@@ -1214,7 +1200,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: scale3d(1,1,1); right: -10px;"
         >
           <span
@@ -1289,7 +1274,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: translateX(16px) translateY(-50%) scale3d(1,1,1); left: 100%; top: -6px;"
         >
           <span
@@ -1364,7 +1348,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: translateX(16px) scale3d(1,1,1); left: 100%; bottom: -10px;"
         >
           <span
@@ -1439,7 +1422,6 @@ exports[`Storyshots ebay-infotip Pointer direction 1`] = `
         </button>
         <span
           class="infotip__overlay"
-          role="tooltip"
           style="transform: translateX(16px) scale3d(1,1,1); left: 100%; top: -100%;"
         >
           <span
@@ -1519,7 +1501,6 @@ exports[`Storyshots ebay-infotip Pointer with custom location 1`] = `
       </button>
       <span
         class="infotip__overlay"
-        role="tooltip"
         style="transform: scale3d(1,1,1); left: -16px; top: 40px;"
       >
         <span
@@ -1586,7 +1567,6 @@ exports[`Storyshots ebay-infotip Text instead of icon 1`] = `
       </button>
       <span
         class="infotip__overlay"
-        role="tooltip"
         style="transform: scale3d(1,1,1); left: -10px;"
       >
         <span

--- a/src/ebay-section-title/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-section-title/__tests__/__snapshots__/index.spec.tsx.snap
@@ -109,7 +109,7 @@ exports[`Storyshots ebay-section-title With Info 1`] = `
       </button>
       <span
         className="infotip__overlay"
-        role="tooltip"
+        role={null}
         style={
           Object {
             "bottom": "auto",

--- a/src/ebay-tourtip/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-tourtip/__tests__/__snapshots__/index.spec.tsx.snap
@@ -16,7 +16,7 @@ exports[`Storyshots ebay-tourtip Default tourtip 1`] = `
       </button>
       <span
         class="tourtip__overlay"
-        role="tooltip"
+        role="region"
         style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
       >
         <span
@@ -77,7 +77,7 @@ exports[`Storyshots ebay-tourtip Footer and heading tourtip 1`] = `
       </button>
       <span
         class="tourtip__overlay"
-        role="tooltip"
+        role="region"
         style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
       >
         <span
@@ -163,7 +163,7 @@ exports[`Storyshots ebay-tourtip Footer tourtip 1`] = `
       </button>
       <span
         class="tourtip__overlay"
-        role="tooltip"
+        role="region"
         style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
       >
         <span
@@ -245,7 +245,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
         >
           <span
@@ -302,7 +302,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: scale3d(1,1,1); left: -10px;"
         >
           <span
@@ -359,7 +359,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: scale3d(1,1,1); right: -10px;"
         >
           <span
@@ -416,7 +416,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: translateX(-16px) translateY(-50%) scale3d(1,1,1); right: 100%; top: -6px;"
         >
           <span
@@ -473,7 +473,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: translateX(-16px) scale3d(1,1,1); right: 100%; bottom: -50%;"
         >
           <span
@@ -530,7 +530,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: translateX(-16px) scale3d(1,1,1); right: 100%; top: -100%;"
         >
           <span
@@ -587,7 +587,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: translateX(-50%) scale3d(1,1,1); left: 50%;"
         >
           <span
@@ -644,7 +644,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: scale3d(1,1,1); left: -10px;"
         >
           <span
@@ -701,7 +701,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: scale3d(1,1,1); right: -10px;"
         >
           <span
@@ -758,7 +758,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: translateX(16px) translateY(-50%) scale3d(1,1,1); left: 100%; top: -6px;"
         >
           <span
@@ -815,7 +815,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: translateX(16px) scale3d(1,1,1); left: 100%; bottom: -10px;"
         >
           <span
@@ -872,7 +872,7 @@ exports[`Storyshots ebay-tourtip Pointer direction 1`] = `
         </a>
         <span
           class="tourtip__overlay"
-          role="tooltip"
+          role="region"
           style="transform: translateX(16px) scale3d(1,1,1); left: 100%; top: -100%;"
         >
           <span
@@ -935,7 +935,7 @@ exports[`Storyshots ebay-tourtip Pointer with custom location 1`] = `
       </a>
       <span
         class="tourtip__overlay"
-        role="tooltip"
+        role="region"
         style="transform: scale3d(1,1,1); left: -16px; top: 40px;"
       >
         <span


### PR DESCRIPTION
Following Marko [implementation](https://github.com/eBay/ebayui-core/blob/master/src/components/components/ebay-tooltip-overlay/index.marko#L28)

- infotip -> remove `role`
- tooltip -> role="tooltip"
- tourtip -> role="region"

Fixes #208 