### PR TITLE
Add buttonPosition attribute check for close icon-button - Dialog

### DIFF
--- a/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/src/ebay-dialog-base/components/dialogBase.tsx
@@ -57,7 +57,7 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
     mainId,
     top,
     header,
-    buttonPosition = 'left',
+    buttonPosition = 'right',
     children,
     ariaLabelledby,
     a11yCloseText,

--- a/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -991,23 +991,6 @@ exports[`Storyshots ebay-drawer-dialog Without Handle 1`] = `
           <h2
             id="dialog-title-abc123"
           />
-          <button
-            class="icon-btn drawer-dialog__close"
-            type="button"
-          >
-            <svg
-              aria-hidden="true"
-              class="icon icon--close"
-              focusable="false"
-              height="24px"
-              width="24px"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <use
-                xlink:href="#icon-close"
-              />
-            </svg>
-          </button>
         </div>
         <div
           class="drawer-dialog__main"

--- a/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-drawer-dialog/__tests__/__snapshots__/index.spec.tsx.snap
@@ -991,6 +991,68 @@ exports[`Storyshots ebay-drawer-dialog Without Handle 1`] = `
           <h2
             id="dialog-title-abc123"
           />
+          <button
+            class="icon-btn drawer-dialog__close"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="icon icon--close"
+              focusable="false"
+              height="24px"
+              width="24px"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <use
+                xlink:href="#icon-close"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          class="drawer-dialog__main"
+        >
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+          </p>
+          <p>
+            <a
+              href="http://www.ebay.com"
+            >
+              www.ebay.com
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`Storyshots ebay-drawer-dialog Without Handle And Close Button 1`] = `
+<DocumentFragment>
+  <button
+    class="btn btn--secondary"
+  >
+    Open Drawer
+  </button>
+  <div>
+    <div
+      aria-labelledby="dialog-title-abc123"
+      arial-modal="true"
+      class="drawer-dialog drawer-dialog--mask-fade-slow"
+      hidden=""
+      role="dialog"
+    >
+      <div
+        class="drawer-dialog__window drawer-dialog__window drawer-dialog__window--slide"
+      >
+        <div
+          class="drawer-dialog__header"
+        >
+          <h2
+            id="dialog-title-abc123"
+          />
         </div>
         <div
           class="drawer-dialog__main"

--- a/src/ebay-drawer-dialog/__tests__/index.spec.tsx
+++ b/src/ebay-drawer-dialog/__tests__/index.spec.tsx
@@ -8,25 +8,26 @@ import {initStoryshots} from '../../../config/jest/storyshots'
 jest.mock('../../common/random-id', () => ({ randomId: () => 'abc123' }))
 
 const classPrefix = 'drawer-dialog'
+let closeDrawerHandler = jest.fn()
+let wrapper
+const renderComponent = (props?: any) => {
+    wrapper = render(
+        <EbayDrawerDialog open onClose={closeDrawerHandler} {...props}>
+            <EbayDialogHeader>Heading</EbayDialogHeader>
+            <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+                incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+                nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+            </p>
+            <p><a href="http://www.ebay.com">www.ebay.com</a></p>
+            <input placeholder="Enter a value" />
+        </EbayDrawerDialog>
+    )
+}
 
 describe('<EbayDrawerDialog>', () => {
-    let closeDrawerHandler
-
     beforeEach(() => {
-        closeDrawerHandler = jest.fn()
-
-        render(
-            <EbayDrawerDialog open onClose={closeDrawerHandler}>
-                <EbayDialogHeader>Heading</EbayDialogHeader>
-                <p>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
-                    incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
-                    nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
-                </p>
-                <p><a href="http://www.ebay.com">www.ebay.com</a></p>
-                <input placeholder="Enter a value" />
-            </EbayDrawerDialog>
-        )
+        renderComponent()
     })
 
     it('should have close button', () => {
@@ -37,6 +38,12 @@ describe('<EbayDrawerDialog>', () => {
         const closeButton = document.querySelector(`button.${classPrefix}__close`)
         fireEvent.click(closeButton)
         expect(closeDrawerHandler).toBeCalled()
+    })
+
+    it('should not render close button when noHandle is set', () => {
+        renderComponent({ noHandle: true })
+        const closeButton = wrapper.container.querySelector(`button.${classPrefix}__close`)
+        expect(closeButton).toBeNull()
     })
 })
 

--- a/src/ebay-drawer-dialog/__tests__/index.spec.tsx
+++ b/src/ebay-drawer-dialog/__tests__/index.spec.tsx
@@ -40,7 +40,7 @@ describe('<EbayDrawerDialog>', () => {
         expect(closeDrawerHandler).toBeCalled()
     })
 
-    it('should not render close button when noHandle is set', () => {
+    it('should not render close button when buttonPosition is set to hidden', () => {
         renderComponent({ buttonPosition: 'hidden' })
         const closeButton = wrapper.container.querySelector(`button.${classPrefix}__close`)
         expect(closeButton).toBeNull()

--- a/src/ebay-drawer-dialog/__tests__/index.spec.tsx
+++ b/src/ebay-drawer-dialog/__tests__/index.spec.tsx
@@ -41,7 +41,7 @@ describe('<EbayDrawerDialog>', () => {
     })
 
     it('should not render close button when noHandle is set', () => {
-        renderComponent({ noHandle: true })
+        renderComponent({ buttonPosition: 'hidden' })
         const closeButton = wrapper.container.querySelector(`button.${classPrefix}__close`)
         expect(closeButton).toBeNull()
     })

--- a/src/ebay-drawer-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-drawer-dialog/__tests__/index.stories.tsx
@@ -58,6 +58,22 @@ export const _WithoutHandle = () => {
     );
 };
 
+export const _WithoutHandleAndCloseButton = () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <EbayButton onClick={() => setOpen(!open)}>Open Drawer</EbayButton>
+            <EbayDrawerDialog noHandle buttonPosition='hidden' open={open} onClose={() => setOpen(false)}>
+                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                <p>
+                    <a href="http://www.ebay.com">www.ebay.com</a>
+                </p>
+            </EbayDrawerDialog>
+        </>
+    );
+};
+
 export const _LotsOfContent = () => {
     const [open, setOpen] = useState(false)
 

--- a/src/ebay-drawer-dialog/components/drawer.tsx
+++ b/src/ebay-drawer-dialog/components/drawer.tsx
@@ -100,7 +100,7 @@ const EbayDrawerDialog: FC<EbayDrawerProps<any>> = ({
         <DialogBaseWithState
             {...rest}
             classPrefix={classPrefix}
-            buttonPosition="right"
+            buttonPosition={noHandle ? 'hidden' : 'right'}
             onCloseBtnClick={onClose}
             className={classNames(rest.className, `${classPrefix}--mask-fade-slow`)}
             windowClass={classNames(`${classPrefix}__window`, `${classPrefix}__window--slide`, {

--- a/src/ebay-drawer-dialog/components/drawer.tsx
+++ b/src/ebay-drawer-dialog/components/drawer.tsx
@@ -100,7 +100,6 @@ const EbayDrawerDialog: FC<EbayDrawerProps<any>> = ({
         <DialogBaseWithState
             {...rest}
             classPrefix={classPrefix}
-            buttonPosition={noHandle ? 'hidden' : 'right'}
             onCloseBtnClick={onClose}
             className={classNames(rest.className, `${classPrefix}--mask-fade-slow`)}
             windowClass={classNames(`${classPrefix}__window`, `${classPrefix}__window--slide`, {


### PR DESCRIPTION
Change:

This PR adds a check to hide the close button on drawer-dialog ( `X`  button ) when `noHandle` attribute is set to true.

![image](https://user-images.githubusercontent.com/115590464/219528433-6f94e533-2294-435f-9e3f-86c4f91ca6bd.png)
