### PR TITLE
Fixing focus issue on drop down components

### DIFF
--- a/src/ebay-select/ebay-select.tsx
+++ b/src/ebay-select/ebay-select.tsx
@@ -59,7 +59,10 @@ const EbaySelect: FC<EbaySelectProps> = ({
         if (!isControlled(controlledValue)) {
             setValue(newValue)
         }
-
+        if (ref?.current) {
+            ref?.current?.focus?.()
+        }
+        
         onChange(e, selectedIndex, newValue)
     }
 


### PR DESCRIPTION
Focus is now returned to the drop down element on changing country or region