### PR TITLE
FIX: EbayInfotip - move drawer as a sibling of the infotip

### DIFF
--- a/src/common/tooltip-utils/tooltip.tsx
+++ b/src/common/tooltip-utils/tooltip.tsx
@@ -29,7 +29,7 @@ const Tooltip: FC<TooltipProps> = ({
     const host = cloneElement(originalHostComponent, {
         className: `${type}__host`,
         'aria-expanded': isExpanded,
-        'aria-describedby': content?.props.id,
+        'aria-describedby': content?.props?.id,
         ...originalHostComponent.props
     })
 

--- a/src/common/tooltip-utils/tooltip.tsx
+++ b/src/common/tooltip-utils/tooltip.tsx
@@ -26,14 +26,10 @@ const Tooltip: FC<TooltipProps> = ({
         throw new Error(`Tooltip: Please use a TooltipHost that defines the host of the tooltip`)
     }
 
-    if (!content) {
-        throw new Error(`Tooltip: Please use a component that defines the content of the tooltip`)
-    }
-
     const host = cloneElement(originalHostComponent, {
         className: `${type}__host`,
         'aria-expanded': isExpanded,
-        'aria-describedby': content.props.id,
+        'aria-describedby': content?.props.id,
         ...originalHostComponent.props
     })
 

--- a/src/ebay-infotip/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-infotip/__tests__/__snapshots__/index.spec.tsx.snap
@@ -487,63 +487,63 @@ exports[`Storyshots ebay-infotip Modal 1`] = `
           />
         </svg>
       </button>
-      <div>
+    </span>
+    <div>
+      <div
+        aria-labelledby="dialog-title-abc123"
+        arial-modal="true"
+        class="drawer-dialog dialog--mini__overlay drawer-dialog--mask-fade-slow"
+        hidden=""
+        mode="mini"
+        role="dialog"
+      >
         <div
-          aria-labelledby="dialog-title-abc123"
-          arial-modal="true"
-          class="drawer-dialog dialog--mini__overlay drawer-dialog--mask-fade-slow"
-          hidden=""
-          mode="mini"
-          role="dialog"
+          class="drawer-dialog__window drawer-dialog__window drawer-dialog__window--slide"
         >
+          <button
+            aria-label="Maximize Text Label"
+            class="drawer-dialog__handle"
+            type="button"
+          />
           <div
-            class="drawer-dialog__window drawer-dialog__window drawer-dialog__window--slide"
+            class="drawer-dialog__header"
           >
+            <h2
+              id="dialog-title-abc123"
+            >
+              <span
+                class="infotip__heading"
+              >
+                Title
+              </span>
+            </h2>
             <button
-              aria-label="Maximize Text Label"
-              class="drawer-dialog__handle"
+              aria-label="Close"
+              class="icon-btn drawer-dialog__close"
               type="button"
-            />
-            <div
-              class="drawer-dialog__header"
             >
-              <h2
-                id="dialog-title-abc123"
+              <svg
+                aria-hidden="true"
+                class="icon icon--close-16"
+                focusable="false"
+                xmlns="http://www.w3.org/2000/svg"
               >
-                <span
-                  class="infotip__heading"
-                >
-                  Title
-                </span>
-              </h2>
-              <button
-                aria-label="Close"
-                class="icon-btn drawer-dialog__close"
-                type="button"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="icon icon--close-16"
-                  focusable="false"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <use
-                    xlink:href="#icon-close-16"
-                  />
-                </svg>
-              </button>
-            </div>
-            <div
-              class="drawer-dialog__main"
-            >
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-              </p>
-            </div>
+                <use
+                  xlink:href="#icon-close-16"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="drawer-dialog__main"
+          >
+            <p>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
           </div>
         </div>
       </div>
-    </span>
+    </div>
   </div>
 </DocumentFragment>
 `;

--- a/src/ebay-infotip/ebay-infotip.tsx
+++ b/src/ebay-infotip/ebay-infotip.tsx
@@ -70,24 +70,41 @@ const EbayInfotip: FC<InfotipProps> = ({
     const { children: contentChildren, ...contentProps } = content.props
 
     return (
-        <Tooltip
-            type="infotip"
-            isExpanded={isExpanded}
-            className={classNames(className, { 'dialog--mini': isModal })}
-            ref={containerRef}>
-            <TooltipHost>
-                {cloneElement(button, {
-                    ref: buttonRef,
-                    onClick: toggleTooltip,
-                    disabled,
-                    variant,
-                    'aria-label': ariaLabel,
-                    'aria-expanded': isExpanded,
-                    icon,
-                    ...button.props
-                })}
-            </TooltipHost>
-            {isModal ? (
+        <>
+
+            <Tooltip
+                type="infotip"
+                isExpanded={isExpanded}
+                className={classNames(className, { 'dialog--mini': isModal })}
+                ref={containerRef}>
+                <TooltipHost>
+                    {cloneElement(button, {
+                        ref: buttonRef,
+                        onClick: toggleTooltip,
+                        disabled,
+                        variant,
+                        'aria-label': ariaLabel,
+                        'aria-expanded': isExpanded,
+                        icon,
+                        ...button.props
+                    })}
+                </TooltipHost>
+                {!isModal && (
+                    <TooltipContent
+                        {...contentProps}
+                        type="infotip"
+                        style={overlayStyle}
+                        pointer={pointer}
+                        showCloseButton
+                        a11yCloseText={a11yCloseText}
+                        onClose={collapseTooltip}
+                    >
+                        {heading}
+                        {contentChildren}
+                    </TooltipContent>
+                )}
+            </Tooltip>
+            {isModal && (
                 <EbayDrawerDialog
                     {...contentProps}
                     open={isExpanded}
@@ -101,21 +118,8 @@ const EbayInfotip: FC<InfotipProps> = ({
                     <EbayDialogHeader>{heading}</EbayDialogHeader>
                     {contentChildren}
                 </EbayDrawerDialog>
-            ) : (
-                <TooltipContent
-                    {...contentProps}
-                    type="infotip"
-                    style={overlayStyle}
-                    pointer={pointer}
-                    showCloseButton
-                    a11yCloseText={a11yCloseText}
-                    onClose={collapseTooltip}
-                >
-                    {heading}
-                    {contentChildren}
-                </TooltipContent>
             )}
-        </Tooltip>
+        </>
     )
 }
 


### PR DESCRIPTION
Fixes #238 

- Move the drawer dialog as a sibling of the infotip in that way styles are not conflicting between infotip and drawer styles

<img width="755" alt="Screen Shot 2023-07-28 at 10 00 13 AM" src="https://github.com/eBay/ebayui-core-react/assets/2222191/a19fccc7-5565-4733-99ac-42c4681ededc">
