### PR TITLE
Fix EbayListboxButton console warning

### DIFF
--- a/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -35,8 +35,8 @@ exports[`Storyshots ebay-listbox-button Borderless 1`] = `
   </button>
   <select
     className="listbox-button__native"
+    defaultValue="BB"
     hidden={true}
-    value="BB"
   >
     <option
       value="AA"
@@ -87,8 +87,8 @@ exports[`Storyshots ebay-listbox-button Default - no selected option 1`] = `
   </button>
   <select
     className="listbox-button__native"
+    defaultValue="AA"
     hidden={true}
-    value="AA"
   >
     <option
       value="AA"
@@ -148,8 +148,8 @@ Array [
     </button>
     <select
       className="listbox-button__native"
+      defaultValue="BB"
       hidden={true}
-      value="BB"
     >
       <option
         value="AA"
@@ -200,8 +200,8 @@ exports[`Storyshots ebay-listbox-button Default 1`] = `
   </button>
   <select
     className="listbox-button__native"
+    defaultValue="BB"
     hidden={true}
-    value="BB"
   >
     <option
       value="AA"
@@ -252,8 +252,8 @@ exports[`Storyshots ebay-listbox-button Disabled State 1`] = `
   </button>
   <select
     className="listbox-button__native"
+    defaultValue="BB"
     hidden={true}
-    value="BB"
   >
     <option
       value="AA"
@@ -309,8 +309,8 @@ exports[`Storyshots ebay-listbox-button Floating label 1`] = `
   </button>
   <select
     className="listbox-button__native"
+    defaultValue="AA"
     hidden={true}
-    value="AA"
   >
     <option
       value="AA"
@@ -360,8 +360,8 @@ exports[`Storyshots ebay-listbox-button Fluid 1`] = `
   </button>
   <select
     className="listbox-button__native"
+    defaultValue="BB"
     hidden={true}
-    value="BB"
   >
     <option
       value="AA"
@@ -412,8 +412,8 @@ exports[`Storyshots ebay-listbox-button Invalid State 1`] = `
   </button>
   <select
     className="listbox-button__native"
+    defaultValue="BB"
     hidden={true}
-    value="BB"
   >
     <option
       value="AA"
@@ -464,8 +464,8 @@ exports[`Storyshots ebay-listbox-button Statefull component 1`] = `
     </button>
     <select
       className="listbox-button__native"
+      defaultValue="California"
       hidden={true}
-      value="California"
     >
       <option
         value="California"
@@ -540,8 +540,8 @@ exports[`Storyshots ebay-listbox-button Too many options 1`] = `
   </button>
   <select
     className="listbox-button__native"
+    defaultValue="BB"
     hidden={true}
-    value="BB"
   >
     <option
       value="AA"

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -286,7 +286,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
                         {updatelistBoxButtonOptions}
                     </div>
                 </div>}
-            <select hidden className="listbox-button__native" name={name} value={selectedOption.props.value}>
+            <select hidden className="listbox-button__native" name={name} defaultValue={selectedOption.props.value}>
                 {
                     updatelistBoxButtonOptions.map((option, i) =>
                         <option value={option.props.value} key={i} />)


### PR DESCRIPTION
ListboxButton is using a hidden uncontrolled select so it behaves as a read-only field, therefore it is not possible to use 'value'.

<img width="607" alt="image" src="https://github.com/eBay/ebayui-core-react/assets/146334008/08081cca-7f1f-48fa-9018-73b9aa087681">

