### PR TITLE
EbayListboxButton: Support missing props [FEAT] [#256]

### DIFF
--- a/src/ebay-listbox-button/README.md
+++ b/src/ebay-listbox-button/README.md
@@ -35,6 +35,7 @@ yarn add @ebay/ui-core-react
 | `borderless`     | boolean | No       | To make the listbox borderless                                                                          |
 | `maxHeight`      | string  | No       | example: 100px, 200px, 10rem                                                                            |
 | `prefixId`       | string  | No       | The id of an external element to use as the a11y prefix label for the listbox button.                   |
+| `prefixLabel`       | string  | No       | The label to add before selected option on the button. Cannot be used with `prefixId`              |
 | `floatingLabel`  | string  | No       | Indicates that the listbox is a floating label type and renders it with a label                         |
 | `unselectedText` | string  | No       | The text to be shown when no options are selected. Default is '-'. Cannot be used with `floating-label` |
 

--- a/src/ebay-listbox-button/README.md
+++ b/src/ebay-listbox-button/README.md
@@ -25,21 +25,23 @@ yarn add @ebay/ui-core-react
 
 ## Attributes
 
-Name | Type | Stateful | Description
---- | --- | --- | ---
-`value` | String | No |
-`aria-disabled` | boolean | No | Set to true if the field is disabled
-`aria-invalid` | boolean | No | Set to true if the field is invalid
-`fluid` | boolean | No | To make the listbox fluid
-`borderless` | boolean | No | To make the listbox borderless
-`maxHeight` | string | No | example: 100px, 200px, 10rem
-`prefixId` | string | No | The id of an external element to use as the a11y prefix label for the listbox button.
-`floatingLabel` | string | No | Indicates that the listbox is a floating label type and renders it with a label
+| Name             | Type    | Required | Description                                                                                             |
+|------------------|---------|----------|---------------------------------------------------------------------------------------------------------|
+| `value`          | string  | No       | Allows you to set the selected option to the one with `value`                                           |
+| `selected`       | number  | No       | Allows you to set the selected index option to `selected`                                               |
+| `aria-disabled`  | boolean | No       | Set to true if the field is disabled                                                                    |
+| `aria-invalid`   | boolean | No       | Set to true if the field is invalid                                                                     |
+| `fluid`          | boolean | No       | To make the listbox fluid                                                                               |
+| `borderless`     | boolean | No       | To make the listbox borderless                                                                          |
+| `maxHeight`      | string  | No       | example: 100px, 200px, 10rem                                                                            |
+| `prefixId`       | string  | No       | The id of an external element to use as the a11y prefix label for the listbox button.                   |
+| `floatingLabel`  | string  | No       | Indicates that the listbox is a floating label type and renders it with a label                         |
+| `unselectedText` | string  | No       | The text to be shown when no options are selected. Default is '-'. Cannot be used with `floating-label` |
 
 ## Callbacks
 
-| Name       | Type     | Required | Description           | Data                                                                         |
-|------------|----------|----------|-----------------------|------------------------------------------------------------------------------|
-| `onChange`  | Function | No       | triggered on change   | `(ChangeEvent, { index: number, selected: string[] , wasClicked: boolean })` |
-| `onCollapse` | Function | No       | triggered on collapse | `()`                                                            |
-| `onExpand`  | Function | No       | triggered on expand   | `()`                                                               |
+| Name         | Type     | Required | Description           | Data                                                                         |
+|--------------|----------|----------|-----------------------|------------------------------------------------------------------------------|
+| `onChange`   | Function | No       | triggered on change   | `(ChangeEvent, { index: number, selected: string[] , wasClicked: boolean })` |
+| `onCollapse` | Function | No       | triggered on collapse | `()`                                                                         |
+| `onExpand`   | Function | No       | triggered on expand   | `()`                                                                         |

--- a/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -62,7 +62,6 @@ exports[`Storyshots ebay-listbox-button Default - no selected option 1`] = `
     onClick={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
-    onSelect={[Function]}
     type="button"
   >
     <span
@@ -71,7 +70,7 @@ exports[`Storyshots ebay-listbox-button Default - no selected option 1`] = `
       <span
         className="btn__text"
       >
-        Option 1
+        -
       </span>
       <svg
         aria-hidden={true}
@@ -88,7 +87,7 @@ exports[`Storyshots ebay-listbox-button Default - no selected option 1`] = `
   <select
     className="listbox-button__native"
     hidden={true}
-    value="AA"
+    value=""
   >
     <option
       value="AA"
@@ -443,7 +442,7 @@ exports[`Storyshots ebay-listbox-button Statefull component 1`] = `
         <span
           className="btn__text"
         >
-          California
+          -
         </span>
         <svg
           aria-hidden={true}
@@ -460,7 +459,7 @@ exports[`Storyshots ebay-listbox-button Statefull component 1`] = `
     <select
       className="listbox-button__native"
       hidden={true}
-      value="California"
+      value=""
     >
       <option
         value="California"

--- a/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -422,6 +422,57 @@ exports[`Storyshots ebay-listbox-button Invalid State 1`] = `
 </span>
 `;
 
+exports[`Storyshots ebay-listbox-button Preselected index 1`] = `
+<span
+  className="listbox-button"
+>
+  <button
+    aria-expanded={false}
+    aria-haspopup="listbox"
+    className="btn btn--form"
+    onClick={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    type="button"
+  >
+    <span
+      className="btn__cell"
+    >
+      <span
+        className="btn__text"
+      >
+        Option 2
+      </span>
+      <svg
+        aria-hidden={true}
+        className="icon icon--chevron-down-16"
+        focusable={false}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlinkHref="#icon-chevron-down-16"
+        />
+      </svg>
+    </span>
+  </button>
+  <select
+    className="listbox-button__native"
+    hidden={true}
+    value="BB"
+  >
+    <option
+      value="AA"
+    />
+    <option
+      value="BB"
+    />
+    <option
+      value="CC"
+    />
+  </select>
+</span>
+`;
+
 exports[`Storyshots ebay-listbox-button Statefull component 1`] = `
 <div>
   <span

--- a/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -278,7 +278,6 @@ exports[`Storyshots ebay-listbox-button Floating label 1`] = `
     onClick={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
-    onSelect={[Function]}
     type="button"
   >
     <span
@@ -408,6 +407,62 @@ exports[`Storyshots ebay-listbox-button Invalid State 1`] = `
     className="listbox-button__native"
     hidden={true}
     value="BB"
+  >
+    <option
+      value="AA"
+    />
+    <option
+      value="BB"
+    />
+    <option
+      value="CC"
+    />
+  </select>
+</span>
+`;
+
+exports[`Storyshots ebay-listbox-button Prefix label 1`] = `
+<span
+  className="listbox-button"
+>
+  <button
+    aria-expanded={false}
+    aria-haspopup="listbox"
+    className="btn btn--form"
+    onClick={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    type="button"
+  >
+    <span
+      className="btn__cell"
+    >
+      <span
+        className="btn__label"
+      >
+        Selected:
+      </span>
+      <span
+        className="btn__text"
+      >
+        -
+      </span>
+      <svg
+        aria-hidden={true}
+        className="icon icon--chevron-down-16"
+        focusable={false}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlinkHref="#icon-chevron-down-16"
+        />
+      </svg>
+    </span>
+  </button>
+  <select
+    className="listbox-button__native"
+    hidden={true}
+    value=""
   >
     <option
       value="AA"

--- a/src/ebay-listbox-button/__tests__/index.spec.tsx
+++ b/src/ebay-listbox-button/__tests__/index.spec.tsx
@@ -54,12 +54,12 @@ describe("<EbayListboxButton>", () => {
         });
         it('should display custom button label', async () => {
             const component = await render(
-                <EbayListboxButton unselectedText="Selected:">
+                <EbayListboxButton unselectedText="Select">
                     <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
                     <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
                 </EbayListboxButton>
             );
-            expect(component.getByRole('button')).toHaveTextContent("Selected:");
+            expect(component.getByRole('button')).toHaveTextContent("Select");
         });
         it('should display button label with selected option', async () => {
             const component = await render(
@@ -69,6 +69,24 @@ describe("<EbayListboxButton>", () => {
                 </EbayListboxButton>
             );
             expect(component.getByRole('button')).toHaveTextContent("Option 2");
+        });
+        it('should display button label with prefix', async () => {
+            const component = await render(
+                <EbayListboxButton prefixLabel="Selected:">
+                    <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
+                    <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
+                </EbayListboxButton>
+            );
+            expect(component.getByRole('button')).toHaveTextContent("Selected:-");
+        });
+        it('should display button label with prefix and selected option', async () => {
+            const component = await render(
+                <EbayListboxButton prefixLabel="Selected:" selected={1}>
+                    <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
+                    <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
+                </EbayListboxButton>
+            );
+            expect(component.getByRole('button')).toHaveTextContent("Selected:Option 2");
         });
         it('should preselect option by index', async () => {
             const component = await render(

--- a/src/ebay-listbox-button/__tests__/index.spec.tsx
+++ b/src/ebay-listbox-button/__tests__/index.spec.tsx
@@ -42,18 +42,51 @@ describe("<EbayListboxButton>", () => {
         });
     });
 
+    describe('on render', () => {
+        it('should display default button label', async () => {
+            const component = await render(
+                <EbayListboxButton>
+                    <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
+                    <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
+                </EbayListboxButton>
+            );
+            expect(component.getByRole('button')).toHaveTextContent("-");
+        });
+        it('should display custom button label', async () => {
+            const component = await render(
+                <EbayListboxButton unselectedText="Selected:">
+                    <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
+                    <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
+                </EbayListboxButton>
+            );
+            expect(component.getByRole('button')).toHaveTextContent("Selected:");
+        });
+        it('should display button label with selected option', async () => {
+            const component = await render(
+                <EbayListboxButton value="BB">
+                    <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
+                    <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
+                </EbayListboxButton>
+            );
+            expect(component.getByRole('button')).toHaveTextContent("Option 2");
+        });
+    });
+
     describe('given the listbox with 3 items', () => {
         let component
         beforeEach(async () => {
             component = await render(
-                    <EbayListboxButton value="BB" prefixId={"listboxBtnLabel"} name="listbox-button-name">
+                    <EbayListboxButton prefixId={"listboxBtnLabel"} name="listbox-button-name">
                         <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
                         <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
                         <EbayListboxButtonOption value="CC">Option 3</EbayListboxButtonOption>
                     </EbayListboxButton>
             );
         });
-        it('then it should not be expanded', () => {
+        it('should display default button label', () => {
+            expect(component.getByRole('button')).toHaveTextContent("-");
+        });
+        it('should not be expanded', () => {
             expect(component.getByRole('button')).toHaveAttribute("aria-expanded", `false`);
         });
 

--- a/src/ebay-listbox-button/__tests__/index.spec.tsx
+++ b/src/ebay-listbox-button/__tests__/index.spec.tsx
@@ -70,6 +70,15 @@ describe("<EbayListboxButton>", () => {
             );
             expect(component.getByRole('button')).toHaveTextContent("Option 2");
         });
+        it('should preselect option by index', async () => {
+            const component = await render(
+                <EbayListboxButton selected={1}>
+                    <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
+                    <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
+                </EbayListboxButton>
+            );
+            expect(component.getByRole('button')).toHaveTextContent("Option 2");
+        });
     });
 
     describe('given the listbox with 3 items', () => {

--- a/src/ebay-listbox-button/__tests__/index.stories.tsx
+++ b/src/ebay-listbox-button/__tests__/index.stories.tsx
@@ -22,9 +22,9 @@ storiesOf(`ebay-listbox-button`, module)
     </>))
     .add(`Default - no selected option`, () => (<>
         <EbayListboxButton
-            onSelect={action(`onSelect triggered`)}
+            onChange={(e: ChangeEvent, props: ChangeEventProps) => action(`onChange`)(e, props)}
         >
-            <EbayListboxButtonOption value="AA" >Option 1</EbayListboxButtonOption>
+            <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
             <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
             <EbayListboxButtonOption value="CC">Option 3</EbayListboxButtonOption>
         </EbayListboxButton>

--- a/src/ebay-listbox-button/__tests__/index.stories.tsx
+++ b/src/ebay-listbox-button/__tests__/index.stories.tsx
@@ -19,6 +19,12 @@ storiesOf(`ebay-listbox-button`, module)
             <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
             <EbayListboxButtonOption value="CC">Option 3</EbayListboxButtonOption>
         </EbayListboxButton>
+    </>))    .add(`Preselected index`, () => (<>
+        <EbayListboxButton selected={1}>
+            <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
+            <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
+            <EbayListboxButtonOption value="CC">Option 3</EbayListboxButtonOption>
+        </EbayListboxButton>
     </>))
     .add(`Default - no selected option`, () => (<>
         <EbayListboxButton

--- a/src/ebay-listbox-button/__tests__/index.stories.tsx
+++ b/src/ebay-listbox-button/__tests__/index.stories.tsx
@@ -19,7 +19,8 @@ storiesOf(`ebay-listbox-button`, module)
             <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
             <EbayListboxButtonOption value="CC">Option 3</EbayListboxButtonOption>
         </EbayListboxButton>
-    </>))    .add(`Preselected index`, () => (<>
+    </>))
+    .add(`Preselected index`, () => (<>
         <EbayListboxButton selected={1}>
             <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
             <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
@@ -127,12 +128,15 @@ storiesOf(`ebay-listbox-button`, module)
             <EbayListboxButtonOption value="102">Option 39</EbayListboxButtonOption>
         </EbayListboxButton>
     </>))
+    .add(`Prefix label`, () => (<>
+        <EbayListboxButton prefixLabel="Selected:">
+            <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
+            <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
+            <EbayListboxButtonOption value="CC">Option 3</EbayListboxButtonOption>
+        </EbayListboxButton>
+    </>))
     .add(`Floating label`, () => (<>
-        <EbayListboxButton
-            value=""
-            floatingLabel="Select"
-            onSelect={action(`onSelect triggered`)}
-        >
+        <EbayListboxButton floatingLabel="Select">
             <EbayListboxButtonOption value="AA">Option 1</EbayListboxButtonOption>
             <EbayListboxButtonOption value="BB">Option 2</EbayListboxButtonOption>
             <EbayListboxButtonOption value="CC">Option 3</EbayListboxButtonOption>

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -20,6 +20,7 @@ export type EbayListboxButtonProps = Omit<ComponentProps<'input'>, 'onChange'> &
     maxHeight?: string;
     prefixId?: string;
     floatingLabel?: string;
+    unselectedText?: string;
     onChange?: EbayChangeEventHandler<HTMLButtonElement, ChangeEventProps>;
     onCollapse?: () => void;
     onExpand?: () => void;
@@ -35,6 +36,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     maxHeight,
     prefixId,
     floatingLabel,
+    unselectedText = '-',
     onChange = () => {},
     onCollapse = () => {},
     onExpand = () => {},
@@ -51,8 +53,9 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
         EbayListboxButtonOption that defines the options of the listbox`)
     }
     const getInitialSelectedOption = (): { option: any, index: number } => {
-        const selectedIndex = listBoxButtonOptions.findIndex(({ props }) => props.value === value)
-        const index = selectedIndex > -1 || floatingLabel ? selectedIndex : 0
+        const selectedIndex = listBoxButtonOptions.findIndex(({ props }) =>
+            value !== undefined && props.value === value)
+        const index = selectedIndex > -1 || floatingLabel ? selectedIndex : undefined
         return {
             option: listBoxButtonOptions[index],
             index
@@ -236,6 +239,16 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     })
     const expandBtnTextId = prefixId && 'expand-btn-text'
 
+    const buttonLabel = floatingLabel ? (
+        <span className="btn__floating-label">
+            {floatingLabel}
+        </span>
+    ) : (
+        <span className="btn__text" id={expandBtnTextId}>
+            {selectedOption?.props.children || unselectedText}
+        </span>
+    )
+
     return (
         <span className={wrapperClassName}>
             <button
@@ -252,15 +265,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
                 ref={buttonRef}
             >
                 <span className="btn__cell">
-                    {floatingLabel ? (
-                        <span className="btn__floating-label">
-                            {floatingLabel}
-                        </span>
-                    ) : null}
-                    {selectedOption &&
-                    <span className="btn__text" id={expandBtnTextId}>
-                        {selectedOption.props.children}
-                    </span>}
+                    {buttonLabel}
                     <EbayIcon name="chevronDown16" />
                 </span>
             </button>

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -20,6 +20,7 @@ export type EbayListboxButtonProps = Omit<ComponentProps<'input'>, 'onChange'> &
     fluid?: boolean;
     maxHeight?: string;
     prefixId?: string;
+    prefixLabel?: string;
     floatingLabel?: string;
     unselectedText?: string;
     onChange?: EbayChangeEventHandler<HTMLButtonElement, ChangeEventProps>;
@@ -37,6 +38,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     className,
     maxHeight,
     prefixId,
+    prefixLabel,
     floatingLabel,
     unselectedText = '-',
     onChange = () => {},
@@ -246,9 +248,12 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
             {floatingLabel}
         </span>
     ) : (
-        <span className="btn__text" id={expandBtnTextId}>
-            {selectedOption?.props.children || unselectedText}
-        </span>
+        <>
+            {prefixLabel && <span className="btn__label">{prefixLabel}</span>}
+            <span className="btn__text" id={expandBtnTextId}>
+                {selectedOption?.props.children || unselectedText}
+            </span>
+        </>
     )
 
     return (

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -15,6 +15,7 @@ export type ChangeEventProps = {
 }
 
 export type EbayListboxButtonProps = Omit<ComponentProps<'input'>, 'onChange'> & {
+    selected?: number;
     borderless?: boolean;
     fluid?: boolean;
     maxHeight?: string;
@@ -30,6 +31,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     children,
     name,
     value,
+    selected,
     borderless,
     fluid,
     className,
@@ -53,7 +55,7 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
         EbayListboxButtonOption that defines the options of the listbox`)
     }
     const getInitialSelectedOption = (): { option: any, index: number } => {
-        const selectedIndex = listBoxButtonOptions.findIndex(({ props }) =>
+        const selectedIndex = selected !== undefined ? selected : listBoxButtonOptions.findIndex(({ props }) =>
             value !== undefined && props.value === value)
         const index = selectedIndex > -1 || floatingLabel ? selectedIndex : undefined
         return {


### PR DESCRIPTION
`unselectedText` - The text to be shown when no options are selected. Default is '-'. Cannot be used with floating-label [storybook case](https://opensource.ebay.com/ebayui-core-react/listbox-button-props/index.html?path=/story/ebay-listbox-button--default-no-selected-option)
`prefixLabel` - The label to add before each selected item on the button. Cannot be used with prefix-id [storybook case](https://opensource.ebay.com/ebayui-core-react/listbox-button-props/index.html?path=/story/ebay-listbox-button--prefix-label)
`selected` - allows you to set the selected index option to selected [storybook case](https://opensource.ebay.com/ebayui-core-react/listbox-button-props/index.html?path=/story/ebay-listbox-button--preselected-index)