### PR TITLE
fix: label text overlap for selected option

### DIFF
--- a/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-listbox-button/__tests__/__snapshots__/index.spec.tsx.snap
@@ -288,6 +288,11 @@ exports[`Storyshots ebay-listbox-button Floating label 1`] = `
       >
         Select
       </span>
+      <span
+        className="btn__text"
+      >
+        -
+      </span>
       <svg
         aria-hidden={true}
         className="icon icon--chevron-down-16"

--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -243,12 +243,10 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     })
     const expandBtnTextId = prefixId && 'expand-btn-text'
 
-    const buttonLabel = floatingLabel ? (
-        <span className="btn__floating-label">
-            {floatingLabel}
-        </span>
-    ) : (
+
+    const buttonLabel = (
         <>
+            {floatingLabel && <span className="btn__floating-label">{floatingLabel}</span>}
             {prefixLabel && <span className="btn__label">{prefixLabel}</span>}
             <span className="btn__text" id={expandBtnTextId}>
                 {selectedOption?.props.children || unselectedText}


### PR DESCRIPTION
Selected option text was not showing for `EbayListboxButton` variant in `Floating Label`.


### Before
![Screenshot 2023-10-15 at 17 10 18](https://github.com/eBay/ebayui-core-react/assets/4152946/9b4a5c99-e71b-4c0c-a362-452e98998a3c)
-----

### After
![Screenshot 2023-10-15 at 17 12 31](https://github.com/eBay/ebayui-core-react/assets/4152946/91bd2e4f-2414-4ce9-a10e-47e2cc6b0de9)
