### PR TITLE
FEAT: Add support for education section notice

### DIFF
--- a/src/ebay-section-notice/README.md
+++ b/src/ebay-section-notice/README.md
@@ -39,12 +39,15 @@ import "@ebay/skin/section-notice";
 
 ## Attributes
 
-| Name                   | Type                                                                 | Stateful | Description                                                                                                                                 | Default    |
-| ---------------------- | -------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| `status`               | String (`"general", "attention"`, `"confirmation"`, or `"information"`) | No       | Determines the style and type of notice to be displayed                                                                                     | `"general"`   |
-| `aria-label`           | String                                                               | No       | The description of the notice itself for screen readers. Check out [this issue](https://github.com/eBay/skin/issues/1001) for more context. | -          |
-| `aria-roledescription` | String                                                               | No       | Adds role description attribute to the section notice                                                                                       | `"Notice"` |
-| `children`             | React Node                                                           | No       | The content to be displayed within the notice. **Must have the EbayNoticeContent within the children!**                                     | -          |
+| Name                   | Type                                                                                | Stateful | Description                                                                                                                                 | Default        |
+| ---------------------- | ----------------------------------------------------------------------------------  | -------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| `status`               | String (`"general", "attention"`, `"confirmation"`, `"information"`, `"education"`) | No       | Determines the style and type of notice to be displayed                                                                                     | `"general"`    |
+| `aria-label`           | String                                                                              | No       | The description of the notice itself for screen readers. Check out [this issue](https://github.com/eBay/skin/issues/1001) for more context. | -              |
+| `aria-roledescription` | String                                                                              | No       | Adds role description attribute to the section notice                                                                                       | `"Notice"`     |
+| `children`             | React Node                                                                          | No       | The content to be displayed within the notice. **Must have the EbayNoticeContent within the children!**                                     | -              |
+| `educationIcon`        | Icon                                                                                | No       | Icon of the educational banner                                                                                                              | `"lightbulb24"`|
+| `iconClass`            | String                                                                              | No       | Class that will be added to the icon svg                                                                                                    | -              |
+| `prominent`            | Boolean                                                                             | No       | Sets the educational banner with a more prominent background                                                                                | `false`        |
 
 ## Callbacks
 | Name | Required             | Description       | Arguments |

--- a/src/ebay-section-notice/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-section-notice/__tests__/__snapshots__/index.spec.tsx.snap
@@ -172,6 +172,126 @@ exports[`<EbaySectionNotice> Storyshots ebay-section-notice Default message (wit
 </DocumentFragment>
 `;
 
+exports[`<EbaySectionNotice> Storyshots ebay-section-notice Educational Section Notice 1`] = `
+<DocumentFragment>
+  <section
+    aria-labelledby="section-notice-education"
+    aria-roledescription="Notice"
+    class="section-notice section-notice--large-icon"
+    role="region"
+  >
+    <div
+      class="section-notice__header"
+      id="section-notice-education"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--lightbulb-24"
+        focusable="false"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-lightbulb-24"
+        />
+      </svg>
+    </div>
+    <div
+      class="section-notice__main"
+    >
+      <p>
+        Items you didn't win will now show in the 
+        <a
+          href="http://www.ebay.com"
+        >
+          Didn't win
+        </a>
+         section of this page.
+      </p>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`<EbaySectionNotice> Storyshots ebay-section-notice Educational Section Notice Custom Icon 1`] = `
+<DocumentFragment>
+  <section
+    aria-labelledby="section-notice-education"
+    aria-roledescription="Notice"
+    class="section-notice section-notice--education section-notice--large-icon"
+    role="region"
+  >
+    <div
+      class="section-notice__header"
+      id="section-notice-education"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--lightning-bolt-24"
+        focusable="false"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-lightning-bolt-24"
+        />
+      </svg>
+    </div>
+    <div
+      class="section-notice__main"
+    >
+      <p>
+        Items you didn't win will now show in the 
+        <a
+          href="http://www.ebay.com"
+        >
+          Didn't win
+        </a>
+         section of this page.
+      </p>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
+exports[`<EbaySectionNotice> Storyshots ebay-section-notice Educational Section Notice Prominent 1`] = `
+<DocumentFragment>
+  <section
+    aria-labelledby="section-notice-education"
+    aria-roledescription="Notice"
+    class="section-notice section-notice--education section-notice--large-icon"
+    role="region"
+  >
+    <div
+      class="section-notice__header"
+      id="section-notice-education"
+    >
+      <svg
+        aria-hidden="true"
+        class="icon icon--lightbulb-24"
+        focusable="false"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <use
+          xlink:href="#icon-lightbulb-24"
+        />
+      </svg>
+    </div>
+    <div
+      class="section-notice__main"
+    >
+      <p>
+        Items you didn't win will now show in the 
+        <a
+          href="http://www.ebay.com"
+        >
+          Didn't win
+        </a>
+         section of this page.
+      </p>
+    </div>
+  </section>
+</DocumentFragment>
+`;
+
 exports[`<EbaySectionNotice> Storyshots ebay-section-notice Information message (dismissable) 1`] = `
 <DocumentFragment>
   <section

--- a/src/ebay-section-notice/__tests__/index.stories.tsx
+++ b/src/ebay-section-notice/__tests__/index.stories.tsx
@@ -158,3 +158,43 @@ export const SectionWithLink = () => (
 SectionWithLink.story = {
     name: 'Section with link'
 }
+
+export const EducationalSectionNotice = () => (
+    <>
+        <EbaySectionNotice status='education'>
+            <EbayNoticeContent>
+                <p>
+                    Items you didn&apos;t win will now show in the{' '}
+                    <a href="http://www.ebay.com">Didn&apos;t win</a> section of this page.
+                </p>
+            </EbayNoticeContent>
+        </EbaySectionNotice>
+    </>
+)
+
+export const EducationalSectionNoticeProminent = () => (
+    <>
+        <EbaySectionNotice status='education' prominent>
+            <EbayNoticeContent>
+                <p>
+                    Items you didn&apos;t win will now show in the{' '}
+                    <a href="http://www.ebay.com">Didn&apos;t win</a> section of this page.
+                </p>
+            </EbayNoticeContent>
+        </EbaySectionNotice>
+    </>
+)
+
+export const EducationalSectionNoticeCustomIcon = () => (
+    <>
+        <EbaySectionNotice status='education' prominent educationIcon="lightningBolt24">
+            <EbayNoticeContent>
+                <p>
+                    Items you didn&apos;t win will now show in the{' '}
+                    <a href="http://www.ebay.com">Didn&apos;t win</a> section of this page.
+                </p>
+            </EbayNoticeContent>
+        </EbaySectionNotice>
+    </>
+)
+

--- a/src/ebay-section-notice/section-notice.tsx
+++ b/src/ebay-section-notice/section-notice.tsx
@@ -13,7 +13,7 @@ import NoticeContent from '../common/notice-utils/notice-content'
 import { EbayIcon, Icon } from '../ebay-icon'
 import { EbaySectionNoticeFooter } from './index'
 
-export type SectionNoticeStatus = 'general' | 'none' | 'attention' | 'confirmation' | 'information'
+export type SectionNoticeStatus = 'general' | 'none' | 'attention' | 'confirmation' | 'information' | 'education'
 export type Props = ComponentProps<'section'> & {
     status?: SectionNoticeStatus;
     'aria-label'?: string;
@@ -21,6 +21,9 @@ export type Props = ComponentProps<'section'> & {
     className?: string;
     a11yDismissText?: string;
     onDismiss?: MouseEventHandler & KeyboardEventHandler;
+    educationIcon?: Icon;
+    iconClass?: string;
+    prominent?: boolean;
 }
 
 const EbaySectionNotice: FC<Props> = ({
@@ -30,6 +33,9 @@ const EbaySectionNotice: FC<Props> = ({
     'aria-label': ariaLabel,
     'aria-roledescription': ariaRoleDescription = 'Notice',
     a11yDismissText,
+    educationIcon,
+    iconClass,
+    prominent,
     onDismiss = () => {},
     ...rest
 }) => {
@@ -37,6 +43,16 @@ const EbaySectionNotice: FC<Props> = ({
     const childrenArray = React.Children.toArray(children) as ReactElement[]
     const content = childrenArray.find(({ type }) => type === EbayNoticeContent)
     const hasStatus = status !== 'general' && status !== 'none'
+    const isEducational = status === 'education'
+    let iconName = null
+
+    if (hasStatus) {
+        if (isEducational) {
+            iconName = educationIcon || 'lightbulb24'
+        } else {
+            iconName = `${status}Filled16` as Icon
+        }
+    }
 
     if (!content) {
         throw new Error(`EbaySectionNotice: Please use a EbayNoticeContent that defines the content of the notice`)
@@ -50,14 +66,18 @@ const EbaySectionNotice: FC<Props> = ({
     return dismissed ? null : (
         <section
             {...rest}
-            className={cx(className, `section-notice`, hasStatus && `section-notice--${status}`)}
+            className={cx(className, `section-notice`, {
+                [`section-notice--${status}`]: hasStatus,
+                'section-notice--education': isEducational && prominent,
+                'section-notice--large-icon': isEducational
+            })}
             role="region"
             aria-label={!hasStatus ? ariaLabel : null}
             aria-labelledby={hasStatus ? `section-notice-${status}` : null}
             aria-roledescription={ariaRoleDescription}>
-            {hasStatus && (
+            {iconName && (
                 <div className="section-notice__header" id={`section-notice-${status}`}>
-                    <EbayIcon name={`${status}Filled16` as Icon} a11yText={ariaLabel} a11yVariant="label" />
+                    <EbayIcon className={iconClass} name={iconName} a11yText={ariaLabel} a11yVariant="label" />
                 </div>
             )}
             <NoticeContent {...content.props} type="section" />


### PR DESCRIPTION
- Add `education` section notice
- Add `prominent`, `iconClass` and `educationIcon` property on section-notice