### PR TITLE
Fixed key up and down use with no selection

### DIFF
--- a/src/ebay-listbox-button/listbox-button.tsx
+++ b/src/ebay-listbox-button/listbox-button.tsx
@@ -157,8 +157,8 @@ const ListboxButton: FC<EbayListboxButtonProps> = ({
     }
 
     const makeSelections = (updatedIndex) => {
-        makeOptionActive(updatedIndex)
-        makeOptionInActive(selectedIndex)
+        makeOptionActive(selectedIndex === undefined || updatedIndex === -1 ? 0 : updatedIndex)
+        makeOptionInActive(selectedIndex === undefined || selectedIndex === -1 ? 0 : selectedIndex)
         scrollOptions(updatedIndex)
         setActiveDescendant(updatedIndex)
         setSelectedIndex(updatedIndex)


### PR DESCRIPTION
This fixes accessibility issue when no option is selected and up and down arrows are used