### PR TITLE
fix: dialog document attach event timeout

### DIFF
--- a/src/ebay-dialog-base/__tests__/index.spec.tsx
+++ b/src/ebay-dialog-base/__tests__/index.spec.tsx
@@ -5,6 +5,8 @@ import DialogBase from '../components/dialogBase';
 import EbayDialogHeader from '../components/dialog-header';
 import { HeaderFooterDialog } from './mocks';
 
+jest.useFakeTimers()
+
 describe('DialogBase', () => {
     it('should use id from header', () => {
         const wrapper = render(
@@ -72,7 +74,8 @@ describe('DialogBase', () => {
                 expect(spyCloseBtnClick).toHaveBeenCalled();
             });
             it('when background clicked then it should trigger onBackgroundClick event', () => {
-                fireEvent.click(wrapper.container.querySelector('.drawer-dialog'));
+                jest.runAllTimers()
+                document.body.click();
                 expect(spyBackgroundClick).toHaveBeenCalled();
             });
         });

--- a/src/ebay-dialog-base/__tests__/index.spec.tsx
+++ b/src/ebay-dialog-base/__tests__/index.spec.tsx
@@ -5,8 +5,6 @@ import DialogBase from '../components/dialogBase';
 import EbayDialogHeader from '../components/dialog-header';
 import { HeaderFooterDialog } from './mocks';
 
-jest.useFakeTimers()
-
 describe('DialogBase', () => {
     it('should use id from header', () => {
         const wrapper = render(
@@ -74,8 +72,7 @@ describe('DialogBase', () => {
                 expect(spyCloseBtnClick).toHaveBeenCalled();
             });
             it('when background clicked then it should trigger onBackgroundClick event', () => {
-                jest.runAllTimers()
-                document.body.click();
+                fireEvent.click(wrapper.container.querySelector('.drawer-dialog'));
                 expect(spyBackgroundClick).toHaveBeenCalled();
             });
         });

--- a/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/src/ebay-dialog-base/components/dialogBase.tsx
@@ -10,7 +10,8 @@ import React, {
     MouseEventHandler,
     ReactNode,
     KeyboardEvent,
-    KeyboardEventHandler
+    KeyboardEventHandler,
+    MouseEvent
 } from 'react'
 import classNames from 'classnames'
 import * as screenreaderTrap from 'makeup-screenreader-trap'
@@ -96,24 +97,6 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
     }, [])
 
     useEffect(() => {
-        const handleBackgroundClick = (e: React.MouseEvent) => {
-            if (drawerBaseEl.current && !drawerBaseEl.current.contains(e.target)) {
-                onBackgroundClick(e)
-            }
-        }
-        if (open && buttonPosition !== 'hidden') {
-            // On React 18 useEffect hooks runs synchronous instead of asynchronous as React 17 or prior
-            // causing the event listener to be attached to the document at the same time that the dialog
-            // opens. Adding a timeout so the event is attached after the click event that opened the modal
-            // is finished.
-            setTimeout(() => {
-                document.addEventListener('click', handleBackgroundClick as any, false)
-            })
-        }
-        return () => document.removeEventListener('click', handleBackgroundClick as any, false)
-    }, [onBackgroundClick, open])
-
-    useEffect(() => {
         if (open && isModal) {
             screenreaderTrap.trap(drawerBaseEl.current)
             keyboardTrap.trap(drawerBaseEl.current)
@@ -153,6 +136,12 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
             onOpen()
         }
     }, [open])
+
+    const handleDialogClick = (e: MouseEvent) => {
+        if (e.currentTarget === e.target && buttonPosition !== 'hidden') {
+            onBackgroundClick(e)
+        }
+    }
 
     function handleFocus(isOpen: boolean) {
         if (isOpen) {
@@ -196,6 +185,7 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
             className={classNames(classPrefix, props.className)}
             aria-live={!isModal ? 'polite' : undefined}
             ref={dialogRef}
+            onClick={handleDialogClick}
             onKeyDown={onKeyDown}
         >
             <div className={classNames(windowClassName, windowClass)} ref={drawerBaseEl}>

--- a/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/src/ebay-dialog-base/components/dialogBase.tsx
@@ -10,8 +10,7 @@ import React, {
     MouseEventHandler,
     ReactNode,
     KeyboardEvent,
-    KeyboardEventHandler,
-    MouseEvent
+    KeyboardEventHandler
 } from 'react'
 import classNames from 'classnames'
 import * as screenreaderTrap from 'makeup-screenreader-trap'
@@ -97,6 +96,24 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
     }, [])
 
     useEffect(() => {
+        const handleBackgroundClick = (e: React.MouseEvent) => {
+            if (drawerBaseEl.current && !drawerBaseEl.current.contains(e.target)) {
+                onBackgroundClick(e)
+            }
+        }
+        if (open && buttonPosition !== 'hidden') {
+            // On React 18 useEffect hooks runs synchronous instead of asynchronous as React 17 or prior
+            // causing the event listener to be attached to the document at the same time that the dialog
+            // opens. Adding a timeout so the event is attached after the click event that opened the modal
+            // is finished.
+            setTimeout(() => {
+                document.addEventListener('click', handleBackgroundClick as any, false)
+            })
+        }
+        return () => document.removeEventListener('click', handleBackgroundClick as any, false)
+    }, [onBackgroundClick, open])
+
+    useEffect(() => {
         if (open && isModal) {
             screenreaderTrap.trap(drawerBaseEl.current)
             keyboardTrap.trap(drawerBaseEl.current)
@@ -136,12 +153,6 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
             onOpen()
         }
     }, [open])
-
-    const handleDialogClick = (e: MouseEvent) => {
-        if (e.currentTarget === e.target && buttonPosition !== 'hidden') {
-            onBackgroundClick(e)
-        }
-    }
 
     function handleFocus(isOpen: boolean) {
         if (isOpen) {
@@ -185,7 +196,6 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
             className={classNames(classPrefix, props.className)}
             aria-live={!isModal ? 'polite' : undefined}
             ref={dialogRef}
-            onClick={handleDialogClick}
             onKeyDown={onKeyDown}
         >
             <div className={classNames(windowClassName, windowClass)} ref={drawerBaseEl}>

--- a/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/src/ebay-dialog-base/components/dialogBase.tsx
@@ -96,7 +96,7 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
     }, [])
 
     useEffect(() => {
-        let timeout: NodeJS.Timeout
+        let timeout: number
         const handleBackgroundClick = (e: React.MouseEvent) => {
             if (drawerBaseEl.current && !drawerBaseEl.current.contains(e.target)) {
                 onBackgroundClick(e)
@@ -107,7 +107,7 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
             // causing the event listener to be attached to the document at the same time that the dialog
             // opens. Adding a timeout so the event is attached after the click event that opened the modal
             // is finished.
-            timeout = setTimeout(() => {
+            timeout = window.setTimeout(() => {
                 document.addEventListener('click', handleBackgroundClick as any, false)
             })
         }

--- a/src/ebay-dialog-base/components/dialogBase.tsx
+++ b/src/ebay-dialog-base/components/dialogBase.tsx
@@ -96,6 +96,7 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
     }, [])
 
     useEffect(() => {
+        let timeout: NodeJS.Timeout
         const handleBackgroundClick = (e: React.MouseEvent) => {
             if (drawerBaseEl.current && !drawerBaseEl.current.contains(e.target)) {
                 onBackgroundClick(e)
@@ -106,11 +107,14 @@ export const DialogBase: FC<DialogBaseProps<HTMLElement>> = ({
             // causing the event listener to be attached to the document at the same time that the dialog
             // opens. Adding a timeout so the event is attached after the click event that opened the modal
             // is finished.
-            setTimeout(() => {
+            timeout = setTimeout(() => {
                 document.addEventListener('click', handleBackgroundClick as any, false)
             })
         }
-        return () => document.removeEventListener('click', handleBackgroundClick as any, false)
+        return () => {
+            clearTimeout(timeout)
+            document.removeEventListener('click', handleBackgroundClick as any, false)
+        }
     }, [onBackgroundClick, open])
 
     useEffect(() => {


### PR DESCRIPTION
Issue related to react `18.2.0` witch will cause `baseDialog` to invoke `useEffect` when updating state for the content inside dialog.  It may happen that attach document click will happen after call cleanup inside useEffect.

Fix: clean timeout each time when useEffect cals cleanup.

