### PR TITLE
#339: Full screen modal: Close button in wrong location

### DIFF
--- a/src/ebay-calendar/__tests__/render.spec.tsx
+++ b/src/ebay-calendar/__tests__/render.spec.tsx
@@ -3,6 +3,10 @@ import { render, screen } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
 import Meta, { Default, Navigable, RangeSelected } from './index.stories'
 
+jest
+    .useFakeTimers()
+    .setSystemTime(new Date('2024-03-05').getTime())
+
 const DefaultStory = composeStory(Default, Meta)
 const NavigableStory = composeStory(Navigable, Meta)
 const RangeSelectedStory = composeStory(RangeSelected, Meta)

--- a/src/ebay-fullscreen-dialog/fullscreen-dialog.tsx
+++ b/src/ebay-fullscreen-dialog/fullscreen-dialog.tsx
@@ -19,7 +19,7 @@ const EbayFullscreenDialog: FC<Props> = ({
     <DialogBaseWithState
         {...rest}
         classPrefix={classPrefix}
-        buttonPosition="left"
+        buttonPosition="right"
         onCloseBtnClick={onClose}
         transitionElement="window"
         animated={animated}


### PR DESCRIPTION
Moving the close button to the right for the full screen modal to match the Marko component. 

Also need to fix one of the tests in Calendar so my PR would pass.