### PR TITLE
fix: removes unnecessary 'role' in <section ...> elements

### DIFF
--- a/src/ebay-page-notice/page-notice.tsx
+++ b/src/ebay-page-notice/page-notice.tsx
@@ -47,8 +47,7 @@ const EbayPageNotice: FC<Props> = ({
         <section
             {...rest}
             aria-labelledby={id || `${status}-status`}
-            className={`page-notice ${status !== `general` ? `page-notice--${status}` : ``}`}
-            role="region">
+            className={`page-notice ${status !== `general` ? `page-notice--${status}` : ``}`}>
             {status !== `general` ? (
                 <div className="page-notice__header" id={id || `${status}-status`}>
                     <EbayIcon

--- a/src/ebay-section-notice/section-notice.tsx
+++ b/src/ebay-section-notice/section-notice.tsx
@@ -71,7 +71,6 @@ const EbaySectionNotice: FC<Props> = ({
                 'section-notice--education': isEducational && prominent,
                 'section-notice--large-icon': isEducational
             })}
-            role="region"
             aria-label={!hasStatus ? ariaLabel : null}
             aria-labelledby={hasStatus ? `section-notice-${status}` : null}
             aria-roledescription={ariaRoleDescription}>


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/region_role#prefer_html, it is not necessary to specify role to `<section>` elements. 