### PR TITLE
fix: fixed drawer windowClass prop

### DIFF
--- a/src/ebay-drawer-dialog/__tests__/index.spec.tsx
+++ b/src/ebay-drawer-dialog/__tests__/index.spec.tsx
@@ -43,4 +43,11 @@ describe('<EbayDrawerDialog>', () => {
         const closeButton = wrapper.container.querySelector(`button.${classPrefix}__close`)
         expect(closeButton).toBeNull()
     })
+
+    it('should apply custom dialog window class', () => {
+        const windowClass = 'windowClassName'
+        renderComponent({ windowClass })
+        const dialogWindow = wrapper.container.querySelector('.drawer-dialog__window')
+        expect(dialogWindow.classList).toContain(windowClass)
+    })
 })

--- a/src/ebay-drawer-dialog/components/drawer.tsx
+++ b/src/ebay-drawer-dialog/components/drawer.tsx
@@ -105,7 +105,7 @@ const EbayDrawerDialog: FC<EbayDrawerProps<any>> = ({
             classPrefix={classPrefix}
             onCloseBtnClick={onClose}
             className={classNames(rest.className, `${classPrefix}--mask-fade-slow`)}
-            windowClass={classNames(`${classPrefix}__window`, `${classPrefix}__window--slide`, {
+            windowClass={classNames(rest.windowClass, `${classPrefix}__window`, `${classPrefix}__window--slide`, {
                 [`${classPrefix}__window--expanded`]: expanded
             })}
             onBackgroundClick={onClose}


### PR DESCRIPTION
Currently the `windowClass` prop is swallowed by the drawer component and not being passed to the DialogBase. This PR fixes that.