### PR TITLE
fix: TypeScript module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,79 +8,79 @@
   "exports": {
     "./ebay-dialog-base/components/animation": {
         "types": "./ebay-dialog-base/components/animation.d.ts",
-        "default": "./ebay-dialog-base/components/animation.js"
+        "default": "./ebay-dialog-base/components/animation/index.js"
     },
     "./ebay-dialog-base/components/dialog-header": {
         "types": "./ebay-dialog-base/components/dialog-header.d.ts",
-        "default": "./ebay-dialog-base/components/dialog-header.js"
+        "default": "./ebay-dialog-base/components/dialog-header/index.js"
     },
     "./ebay-dialog-base/components/dialog-footer": {
         "types": "./ebay-dialog-base/components/dialog-footer.d.ts",
-        "default": "./ebay-dialog-base/components/dialog-footer.js"
+        "default": "./ebay-dialog-base/components/dialog-footer/index.js"
     },
     "./ebay-notice-base/components/*": {
         "types": "./ebay-notice-base/index.d.ts",
-        "default": "./ebay-notice-base.js"
+        "default": "./ebay-notice-base/index.js"
     },
     "./common/component-utils/forwardRef": {
       "types": "./common/component-utils/forwardRef.d.ts",
-      "default": "./common/component-utils/forwardRef.js"
+      "default": "./common/component-utils/forwardRef/index.js"
     },
     "./common/component-utils/utils": {
       "types": "./common/component-utils/utils.d.ts",
-      "default": "./common/component-utils/utils.js"
+      "default": "./common/component-utils/utils/index.js"
     },
     "./common/component-utils": {
       "types": "./common/component-utils/index.d.ts",
-      "default": "./common/component-utils.js"
+      "default": "./common/component-utils/index.js"
     },
     "./common/event-utils/types": {
-      "types": "./common/event-utils/event-utils/types.d.ts"
+      "types": "./common/event-utils/types.d.ts"
     },
     "./common/event-utils": {
-      "types": "./common/event-utils/event-utils/index.d.ts",
-      "default": "./common/event-utils/event-utils.js"
+      "types": "./common/event-utils/index.d.ts",
+      "default": "./common/event-utils/index.js"
     },
     "./common/floating-label-utils": {
       "types": "./common/floating-label-utils/hooks.d.ts",
-      "default": "./common/floating-label-utils/hooks.js"
+      "default": "./common/floating-label-utils/hooks/index.js"
     },
     "./common/notice-utils/notice-cta": {
       "types": "./common/notice-utils/notice-cta.d.ts",
-      "default": "./common/notice-utils/notice-cta.js"
+      "default": "./common/notice-utils/notice-cta/index.js"
     },
     "./common/random-id": {
       "types": "./common/random-id.d.ts",
-      "default": "./common/random-id.js"
+      "default": "./common/random-id/index.js"
     },
     "./common/tooltip-utils/constants": {
       "types": "./common/tooltip-utils/constants.d.ts",
-      "default": "./common/tooltip-utils/constants.js"
+      "default": "./common/tooltip-utils/constants/index.js"
     },
     "./common/tooltip-utils/types": {
       "types": "./common/tooltip-utils/types.d.ts"
     },
     "./common/tooltip-utils": {
       "types": "./common/tooltip-utils/index.d.ts",
-      "default": "./common/tooltip-utils.js"
+      "default": "./common/tooltip-utils/index.js"
     },
     "./ebay-radio/radio": {
       "types": "./ebay-radio/radio.d.ts",
-      "default": "./ebay-radio/radio.js"
+      "default": "./ebay-radio/radio/index.js"
     },
     "./ebay-fake-menu-button/menu-button": {
       "types": "./ebay-fake-menu-button/menu-button.d.ts",
-      "default": "./ebay-fake-menu-button/menu-button.js"
+      "default": "./ebay-fake-menu-button/menu-button/index.js"
     },
     "./ebay-fake-menu/menu-item": {
       "types": "./ebay-fake-menu/menu-item.d.ts",
-      "default": "./ebay-fake-menu/menu-item.js"
+      "default": "./ebay-fake-menu/menu-item/index.js"
     },
 
     "./package.json": "./package.json",
     "./*": {
       "types": "./*/index.d.ts",
-      "default": "./*.js"
+      "default": "./*/index.js"
     }
   },
   "scripts": {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -37,7 +37,7 @@ export default defineConfig({
     build: {
         lib: {
             entry: componentEntries,
-            fileName: "[name]",
+            fileName: "[name]/index",
             // Use CommonJS only until we upgrade all packages that uses ui-core-react to use ESM.
             // If we use ESM, the bundle might have both ESM and CJS, which will increase the bundle size,
             // and might cause reference issues.


### PR DESCRIPTION
# Description
Rename files to be `/<component-name>/index.js` instead of `/<component-name>.js` so it maintains typescript definition files

# Context

The current `dist` folder structure is:

```
/dist
    /ebay-button
          /index.d.ts
   ebay-button.js
```

This is causing an issue when imported internally (for example the `ebay-dialog-base`) where typescript is conflicting with which file to solve (is it `root/name/index.d.ts` or is it `root/name.js`).