### PR TITLE
fix(EbayCarousel): Update icon size to 16

### DIFF
--- a/.changeset/thin-ducks-develop.md
+++ b/.changeset/thin-ducks-develop.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(EbayCarousel): Update icon size to 16

--- a/src/ebay-carousel/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/ebay-carousel/__tests__/__snapshots__/index.spec.tsx.snap
@@ -8,12 +8,12 @@ exports[`ebay-carousel rendering renders continuous story correctly 1`] = `
 >
   <svg
     aria-hidden="true"
-    class="icon icon--carousel-prev icon icon--12"
+    class="icon icon--carousel-prev icon icon--16"
     focusable="false"
     xmlns="http://www.w3.org/2000/svg"
   >
     <use
-      xlink:href="#icon-chevron-left-12"
+      xlink:href="#icon-chevron-left-16"
     />
   </svg>
 </button>
@@ -27,12 +27,12 @@ exports[`ebay-carousel rendering renders continuous story correctly 2`] = `
 >
   <svg
     aria-hidden="true"
-    class="icon icon--carousel-next icon icon--12"
+    class="icon icon--carousel-next icon icon--16"
     focusable="false"
     xmlns="http://www.w3.org/2000/svg"
   >
     <use
-      xlink:href="#icon-chevron-right-12"
+      xlink:href="#icon-chevron-right-16"
     />
   </svg>
 </button>

--- a/src/ebay-carousel/carousel-control-button.tsx
+++ b/src/ebay-carousel/carousel-control-button.tsx
@@ -12,8 +12,8 @@ type CarouselControlProps = {
 }
 
 const icon: Record<CarouselControlType, Icon> = {
-    prev: 'chevronLeft12',
-    next: 'chevronRight12'
+    prev: 'chevronLeft16',
+    next: 'chevronRight16'
 }
 
 const typeToDirection: Record<CarouselControlType, MovementDirection> = {


### PR DESCRIPTION
# Description

- Change arrow icons size from 12 to 16