### PR TITLE
core: fix fork GH action deploy condition

### DIFF
--- a/.changeset/late-shoes-divide.md
+++ b/.changeset/late-shoes-divide.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+core: fix GH action fork condition

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
         needs: build-test
         runs-on: ubuntu-latest
         # Deploy storybook only on branches, ignoring forks
-        if: "${{ !github.action.pull_request.head.repo.fork }}"
+        if: "${{ github.event.pull_request.head.repo.full_name == github.repository }}"
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/setup-node

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
         needs: build-test
         runs-on: ubuntu-latest
         # Deploy storybook only on branches, ignoring forks
-        if: "${{ github.repository_owner == 'ebay' }}"
+        if: "${{ !github.action.pull_request.head.repo.fork }}"
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/setup-node


### PR DESCRIPTION
# Description

- Check that the owner pull request repository is the same as the origin

Tested in this fork PR build (skip deploy): https://github.com/eBay/ebayui-core-react/actions/runs/12837673345
And this PR branch (deploy): https://github.com/eBay/ebayui-core-react/actions/runs/12837717464?pr=404