### PR TITLE
feat(EbayLightboxDialog): add support for banner image

### DIFF
--- a/.changeset/wicked-wasps-rush.md
+++ b/.changeset/wicked-wasps-rush.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": minor
+---
+
+feat(EbayLightboxDialog): add support for banner image

--- a/src/ebay-lightbox-dialog/README.md
+++ b/src/ebay-lightbox-dialog/README.md
@@ -24,7 +24,6 @@ Name | Type | Stateful | Required | Description
 `animated` | Boolean | Yes | No | Renders the dialog with an animation. Note that the dialog will always be present in the DOM
 `bannerImgSrc` | String | No | No | Image source for the expressive variant
 `bannerImgPosition` | String | No | No | Position of the image within the given bounds using the CSS `background-position` property. Options include [keywords, lengths, and edge distances](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position)
-`a11yBannerText` | String | No | No | A11y text for the banner image
 
 ## Events
 

--- a/src/ebay-lightbox-dialog/README.md
+++ b/src/ebay-lightbox-dialog/README.md
@@ -22,6 +22,9 @@ Name | Type | Stateful | Required | Description
 `focus` | String | No | No | An id for an element which will receive focus when the drawer opens (defaults to close button).
 `a11yCloseText` | String | No | Yes | A11y text for close button and mask.
 `animated` | Boolean | Yes | No | Renders the dialog with an animation. Note that the dialog will always be present in the DOM
+`bannerImgSrc` | String | No | No | Image source for the expressive variant
+`bannerImgPosition` | String | No | No | Position of the image within the given bounds using the CSS `background-position` property. Options include [keywords, lengths, and edge distances](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position)
+`a11yBannerText` | String | No | No | A11y text for the banner image
 
 ## Events
 

--- a/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
@@ -40,10 +40,6 @@ const story: Meta<typeof EbayLightboxDialog> = {
             description:
                 "Position of the image within the given bounds using the CSS `background-position` property. Options include [keywords, lengths, and edge distances](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position)",
         },
-        a11yBannerText: {
-            control: { type: "text" },
-            description: "A11y text for the banner image.",
-        },
         size: {
             options: ["regular", "wide", "narrow", "large"],
             description: "The size of the dialog",

--- a/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
+++ b/src/ebay-lightbox-dialog/__tests__/index.stories.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react'
+import { Meta, StoryFn } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
 import {
     EbayDialogFooter,
     EbayDialogHeader,
@@ -8,12 +10,72 @@ import { EbayButton } from '../../ebay-button'
 import { EbayCheckbox } from '../../ebay-checkbox'
 import { EbayLabel } from '../../ebay-field'
 import { EbayLightboxDialog } from '../index'
-import { action } from '@storybook/addon-actions'
 
-const story: any = {
+
+const story: Meta<typeof EbayLightboxDialog> = {
+    title: 'dialogs/ebay-lightbox-dialog',
     component: EbayLightboxDialog,
-    title: 'dialogs/ebay-lightbox-dialog'
-}
+
+    argTypes: {
+        open: {
+            type: "boolean",
+            control: { type: "boolean" },
+            description: "Whether dialog is open.",
+        },
+        focus: {
+            control: { type: "text" },
+            description:
+                "An id for an element which will receive focus when the dialog opens (defaults to close button).",
+        },
+        a11yCloseText: {
+            control: { type: "text" },
+            description: "A11y text for close button and mask.",
+        },
+        bannerImgSrc: {
+            control: { type: "text" },
+            description: "Image source for the expressive variant",
+        },
+        bannerImgPosition: {
+            control: { type: "text" },
+            description:
+                "Position of the image within the given bounds using the CSS `background-position` property. Options include [keywords, lengths, and edge distances](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position)",
+        },
+        a11yBannerText: {
+            control: { type: "text" },
+            description: "A11y text for the banner image.",
+        },
+        size: {
+            options: ["regular", "wide", "narrow", "large"],
+            description: "The size of the dialog",
+            table: {
+                defaultValue: {
+                    summary: "regular",
+                },
+            },
+            type: { category: "Options" },
+        },
+        onOpen: {
+            action: "onOpen",
+            description: "Triggered on dialog opened",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        },
+        onClose: {
+            action: "onClose",
+            description: "Triggered on dialog closed.",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "",
+                },
+            },
+        },
+    },
+};
 
 const textParagraph = (
     <p>
@@ -25,7 +87,7 @@ const textParagraph = (
     </p>
 )
 
-export const _Default = () => {
+export const Default: StoryFn<typeof EbayLightboxDialog> = (args) => {
     const [open, setOpen] = useState(false)
     const close = () => setOpen(false)
     return (
@@ -35,11 +97,12 @@ export const _Default = () => {
             </button>
             <p>Some outside content...</p>
             <EbayLightboxDialog
+                {...args}
                 open={open}
                 onOpen={() => action('onOpen')()}
                 onClose={() => {
                     action('onClose')()
-                    setOpen(false)
+                    close()
                 }}
                 a11yCloseText="Close"
             >
@@ -59,10 +122,10 @@ export const _Default = () => {
     )
 }
 
-export const _AlwaysOpened = () => (
+export const AlwaysOpened: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
-        <EbayLightboxDialog open a11yCloseText="Close dialog">
+        <EbayLightboxDialog {...args} open a11yCloseText="Close dialog">
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
             <p>
@@ -72,10 +135,10 @@ export const _AlwaysOpened = () => (
     </div>
 )
 
-export const _ScrollingContent = () => (
+export const ScrollingContent: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
-        <EbayLightboxDialog open a11yCloseText="Close">
+        <EbayLightboxDialog {...args} open a11yCloseText="Close">
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
             {textParagraph}
@@ -94,10 +157,10 @@ export const _ScrollingContent = () => (
     </div>
 )
 
-export const _MiniDialog = () => (
+export const MiniDialog: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
-        <EbayLightboxDialog mode="mini" open a11yCloseText="Close">
+        <EbayLightboxDialog {...args} mode="mini" open a11yCloseText="Close">
             <EbayDialogHeader />
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
@@ -107,7 +170,7 @@ export const _MiniDialog = () => (
     </div>
 )
 
-export const _DisableDialogClose = () => {
+export const DisableDialogClose: StoryFn<typeof EbayLightboxDialog> = (args) => {
     const [showDialog, setShowDialog] = useState(false)
     const [dialogCloseable, setDialogCloseable] = useState(true)
     const closeDialog = () => {
@@ -120,7 +183,7 @@ export const _DisableDialogClose = () => {
         <div>
             <EbayButton onClick={() => setShowDialog(!showDialog)}>Show Dialog</EbayButton>
 
-            <EbayLightboxDialog open={showDialog} onClose={closeDialog} a11yCloseText="Close">
+            <EbayLightboxDialog {...args} open={showDialog} onClose={closeDialog} a11yCloseText="Close">
                 <EbayDialogHeader>Heading</EbayDialogHeader>
 
                 <p>Unselect the following checkbox to prevent user to close the dialog</p>
@@ -150,7 +213,7 @@ export const _DisableDialogClose = () => {
     )
 }
 
-export const _WithAnimation = () => {
+export const WithAnimation: StoryFn<typeof EbayLightboxDialog> = (args) => {
     const [open, setOpen] = useState(false)
     const close = () => setOpen(false)
     return (
@@ -159,7 +222,7 @@ export const _WithAnimation = () => {
                 Open Dialog
             </button>
             <p>Some outside content...</p>
-            <EbayLightboxDialog open={open} onClose={close} animated a11yCloseText="Close">
+            <EbayLightboxDialog {...args} open={open} onClose={close} animated a11yCloseText="Close">
                 <EbayDialogHeader>Heading</EbayDialogHeader>
                 {textParagraph}
                 <p>
@@ -175,7 +238,7 @@ export const _WithAnimation = () => {
         </div>
     )
 }
-export const _WithNoBackgroundClick = () => {
+export const WithNoBackgroundClick: StoryFn<typeof EbayLightboxDialog> = (args) => {
     const [open, setOpen] = useState(false)
     const close = () => setOpen(false)
     return (
@@ -184,7 +247,7 @@ export const _WithNoBackgroundClick = () => {
                 Open Dialog
             </button>
             <p>Some outside content...</p>
-            <EbayLightboxDialog open={open} onClose={close} buttonPosition="hidden" a11yCloseText="Close">
+            <EbayLightboxDialog {...args} open={open} onClose={close} buttonPosition="hidden" a11yCloseText="Close">
                 <EbayDialogHeader>Heading</EbayDialogHeader>
                 {textParagraph}
                 <p>
@@ -201,10 +264,10 @@ export const _WithNoBackgroundClick = () => {
     )
 }
 
-export const _WithPreviousButton = () => (
+export const WithPreviousButton: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
-        <EbayLightboxDialog open a11yCloseText="Close dialog">
+        <EbayLightboxDialog {...args} open a11yCloseText="Close dialog">
             <EbayDialogPreviousButton aria-label="Previous" onClick={action('previous button click')} />
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
@@ -215,10 +278,10 @@ export const _WithPreviousButton = () => (
     </div>
 )
 
-export const _WithWideSize = () => (
+export const WithWideSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
-        <EbayLightboxDialog open a11yCloseText="Close dialog" size="wide">
+        <EbayLightboxDialog {...args} open a11yCloseText="Close dialog" size="wide">
             <EbayDialogPreviousButton aria-label="Previous" onClick={action('previous button click')} />
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
@@ -229,10 +292,10 @@ export const _WithWideSize = () => (
     </div>
 )
 
-export const _WithNarrowSize = () => (
+export const WithNarrowSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
-        <EbayLightboxDialog open a11yCloseText="Close dialog" size="narrow">
+        <EbayLightboxDialog {...args} open a11yCloseText="Close dialog" size="narrow">
             <EbayDialogPreviousButton aria-label="Previous" onClick={action('previous button click')} />
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
@@ -243,10 +306,10 @@ export const _WithNarrowSize = () => (
     </div>
 )
 
-export const _WithFullscreenSize = () => (
+export const WithFullscreenSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
-        <EbayLightboxDialog open a11yCloseText="Close dialog" size="fullscreen">
+        <EbayLightboxDialog {...args} open a11yCloseText="Close dialog" size="fullscreen">
             <EbayDialogPreviousButton aria-label="Previous" onClick={action('previous button click')} />
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
@@ -257,10 +320,10 @@ export const _WithFullscreenSize = () => (
     </div>
 )
 
-export const _WithLargeSize = () => (
+export const WithLargeSize: StoryFn<typeof EbayLightboxDialog> = (args) => (
     <div>
         <p>Some outside content...</p>
-        <EbayLightboxDialog open a11yCloseText="Close dialog" size="large">
+        <EbayLightboxDialog {...args} open a11yCloseText="Close dialog" size="large">
             <EbayDialogPreviousButton aria-label="Previous" onClick={action('previous button click')} />
             <EbayDialogHeader>Heading</EbayDialogHeader>
             {textParagraph}
@@ -270,5 +333,35 @@ export const _WithLargeSize = () => (
         </EbayLightboxDialog>
     </div>
 )
+
+export const Expressive: StoryFn<typeof EbayLightboxDialog> = (args) => {
+    const [open, setOpen] = useState(false)
+
+    return (
+        <div>
+            <button className="btn btn--secondary" onClick={() => setOpen(!open)}>
+                Open Dialog
+            </button>
+            <EbayLightboxDialog
+                {...args}
+                bannerImgSrc="http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg"
+                bannerImgPosition="top"
+                open={open}
+                onOpen={() => action('onOpen')()}
+                onClose={() => {
+                    action('onClose')()
+                    setOpen(false)
+                }}
+                a11yCloseText="Close"
+            >
+                <EbayDialogHeader>Heading Text</EbayDialogHeader>
+                {textParagraph}
+                <p>
+                    <a href="http://www.ebay.com">www.ebay.com</a>
+                </p>
+            </EbayLightboxDialog>
+        </div>
+    )
+}
 
 export default story

--- a/src/ebay-lightbox-dialog/__tests__/render.spec.tsx
+++ b/src/ebay-lightbox-dialog/__tests__/render.spec.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { composeStories } from '@storybook/react'
+import * as stories from './index.stories'
+
+const { Expressive } = composeStories(stories)
+
+describe('<EbayLightboxDialog /> render', () => {
+    it('should render the expressive dialog when passing bannerImgSrc', () => {
+        const { container } = render(
+            <Expressive />
+        )
+
+        expect(container.querySelector('.lightbox-dialog--expressive')).toBeInTheDocument()
+
+        const imageContainer = container.querySelector('.lightbox-dialog__image')
+        expect(imageContainer).toBeInTheDocument()
+        expect(imageContainer).toHaveStyle('background-image: url(http://ir.ebaystatic.com/cr/v/c1/skin/image-treatment/mountain.jpeg)')
+    })
+})

--- a/src/ebay-lightbox-dialog/lightbox-dialog.tsx
+++ b/src/ebay-lightbox-dialog/lightbox-dialog.tsx
@@ -1,8 +1,6 @@
-import React, { FC } from 'react'
+import React, { CSSProperties, FC } from 'react'
 import classNames from 'classnames'
 import { DialogBaseProps, DialogBaseWithState } from '../ebay-dialog-base'
-
-const classPrefix = 'lightbox-dialog'
 
 type Mode = 'default' | 'mini'
 type Size = 'wide' | 'narrow' | 'fullscreen' | 'large'
@@ -11,6 +9,9 @@ export type Props<T = any> = Omit<DialogBaseProps<T>, 'size'> & {
   open?: boolean;
   mode?: Mode;
   size?: Size;
+  bannerImgSrc?: string;
+  bannerImgPosition?: CSSProperties['backgroundPosition'];
+  a11yBannerText?: string;
   onClose?: () => void;
 }
 
@@ -18,21 +19,44 @@ const EbayLightboxDialog: FC<Props> = ({
     open,
     mode,
     size,
+    bannerImgSrc,
+    bannerImgPosition,
+    a11yBannerText,
     onClose = () => {},
     ...rest
-}) => (
-    <DialogBaseWithState
-        buttonPosition="right"
-        {...rest}
-        classPrefix={classPrefix}
-        onCloseBtnClick={onClose}
-        onBackgroundClick={onClose}
-        className={classNames(rest.className, `${classPrefix}--mask-fade`, size && `${classPrefix}--${size}`)}
-        windowClass={classNames('lightbox-dialog__window--fade', {
-            [`${classPrefix}__window--mini`]: mode === 'mini'
-        })}
-        open={open}
-    />
-)
+}) => {
+    const top = bannerImgSrc ? (
+        <div
+            className="lightbox-dialog__image"
+            role="img"
+            aria-label={a11yBannerText}
+            style={{
+                backgroundImage: `url(${bannerImgSrc})`,
+                backgroundPosition: bannerImgPosition
+            }} />
+    ) : null
 
+    return (
+        <DialogBaseWithState
+            buttonPosition="right"
+            {...rest}
+            classPrefix="lightbox-dialog"
+            onCloseBtnClick={onClose}
+            onBackgroundClick={onClose}
+            className={classNames(
+                rest.className,
+                'lightbox-dialog--mask-fade',
+                {
+                    [`lightbox-dialog--${size}`]: size,
+                    'lightbox-dialog--expressive': bannerImgSrc
+                }
+            )}
+            windowClass={classNames('lightbox-dialog__window--fade', {
+                'lightbox-dialog__window--mini': mode === 'mini'
+            })}
+            top={top}
+            open={open}
+        />
+    )
+}
 export default EbayLightboxDialog

--- a/src/ebay-lightbox-dialog/lightbox-dialog.tsx
+++ b/src/ebay-lightbox-dialog/lightbox-dialog.tsx
@@ -11,7 +11,6 @@ export type Props<T = any> = Omit<DialogBaseProps<T>, 'size'> & {
   size?: Size;
   bannerImgSrc?: string;
   bannerImgPosition?: CSSProperties['backgroundPosition'];
-  a11yBannerText?: string;
   onClose?: () => void;
 }
 
@@ -21,15 +20,12 @@ const EbayLightboxDialog: FC<Props> = ({
     size,
     bannerImgSrc,
     bannerImgPosition,
-    a11yBannerText,
     onClose = () => {},
     ...rest
 }) => {
     const top = bannerImgSrc ? (
         <div
             className="lightbox-dialog__image"
-            role="img"
-            aria-label={a11yBannerText}
             style={{
                 backgroundImage: `url(${bannerImgSrc})`,
                 backgroundPosition: bannerImgPosition


### PR DESCRIPTION
# Description

- Add `bannerImgSrc`, `bannerImgPositition` new attributes
- Add types on stories and remove `_` from the name
- Add stories controls on lightbox dialog
- Remove unnecessary `classPrefix` variable for better reading and understanding of the skin class name usage