### PR TITLE
fix(EbayFakeMenuButton): use btn-cell to add margin between chevron and action content

### DIFF
--- a/.changeset/honest-parents-remember.md
+++ b/.changeset/honest-parents-remember.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(EbayFakeMenuButton): use btn-cell to add margin with chevron and action content

--- a/src/ebay-fake-menu-button/menu-button.tsx
+++ b/src/ebay-fake-menu-button/menu-button.tsx
@@ -120,10 +120,10 @@ const EbayMenuButton: FC<Props> = ({
                 <EbayIconButton icon="overflowHorizontal24" {...buttonProps} /> :
                 <EbayButton
                     variant={variant === 'form' ? 'form' : undefined}
+                    bodyState={!noToggleIcon ? 'expand' : undefined}
                     {...buttonProps}
                 >
                     {icon}{label}
-                    {!noToggleIcon && <EbayIcon name="chevronDown12" />}
                 </EbayButton>
             }
             {expanded &&


### PR DESCRIPTION
`FakeMenuButton` and `MenuButton` have a different HTML structure, here we are putting the `btn-cell` back as it was before  for fake menu button

<img width="144" alt="Screenshot 2025-02-07 at 8 42 41 AM" src="https://github.com/user-attachments/assets/bb8691ac-5e7f-4be9-a9bf-0382650f5bd9" />

<img width="230" alt="Screenshot 2025-02-07 at 8 42 54 AM" src="https://github.com/user-attachments/assets/f8c855c1-7886-4899-968d-896acf7a9deb" />

https://opensource.ebay.com/ebayui-core-react/fix-fake-menu-button/index.html?path=/story/buttons-ebay-fake-menu-button--default
