### PR TITLE
fix: use target es2015 instead of esnext for better compatibility

### DIFF
--- a/.changeset/neat-suns-explode.md
+++ b/.changeset/neat-suns-explode.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix: use target es2015 instead of esnext for better compatibility

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2015",
     "module": "ESNext",
     "lib": [
         "dom",


### PR DESCRIPTION
nullish coalescing (`??`) is not supported on Webpack 4, updating the typescript target so it supported accross different builders.