### PR TITLE
fix: add all makeup libraries to cjsInterop plugin

### DIFF
--- a/.changeset/pink-waves-repair.md
+++ b/.changeset/pink-waves-repair.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix: add makeup to cjsInterop plugin for better comptability

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -25,7 +25,11 @@ export default defineConfig({
             // By default this plugin is only for SSR vite build, here we are in library mode, so we enable "client"
             client: true,
             dependencies: [
+                'makeup-active-descendant',
                 'makeup-expander',
+                'makeup-floating-label',
+                'makeup-keyboard-trap',
+                'makeup-screenreader-trap',
                 'makeup-typeahead',
             ]
         })

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -25,12 +25,9 @@ export default defineConfig({
             // By default this plugin is only for SSR vite build, here we are in library mode, so we enable "client"
             client: true,
             dependencies: [
-                'makeup-active-descendant',
                 'makeup-expander',
-                'makeup-floating-label',
-                'makeup-keyboard-trap',
-                'makeup-screenreader-trap',
                 'makeup-typeahead',
+                'makeup-floating-label'
             ]
         })
     ],


### PR DESCRIPTION
In some bundles this is causing `E is not a constructor`