### PR TITLE
fix(Select): remove floating-label--inline class on first render

### DIFF
--- a/.changeset/fast-seas-kick.md
+++ b/.changeset/fast-seas-kick.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": patch
+---
+
+fix(Select): remove floating-label inline class on first render"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint": "eslint . --ext .ts,.tsx -f checkstyle -o ./lint/checkstyle-result.xml",
     "format": "eslint . --fix 'src/**/*.{ts,tsx}'",
     "storybook": "NODE_OPTIONS=--openssl-legacy-provider storybook dev -p 9001 -c .storybook",
-    "storybook-node16": "storybook dev -p 9001 -c .storybook",
     "build-storybook": "storybook build",
     "storybook:publish": "NODE_OPTIONS=--openssl-legacy-provider yarn build-storybook --output-dir storybook-static/$(git branch --show-current) && gh-pages --add --message=\"Deploying to gh-pages from @ eBay/ebayui-core-react@$(git rev-parse --short HEAD) 🚀\" -d storybook-static",
     "test": "yarn jest",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint": "eslint . --ext .ts,.tsx -f checkstyle -o ./lint/checkstyle-result.xml",
     "format": "eslint . --fix 'src/**/*.{ts,tsx}'",
     "storybook": "NODE_OPTIONS=--openssl-legacy-provider storybook dev -p 9001 -c .storybook",
+    "storybook-node16": "storybook dev -p 9001 -c .storybook",
     "build-storybook": "storybook build",
     "storybook:publish": "NODE_OPTIONS=--openssl-legacy-provider yarn build-storybook --output-dir storybook-static/$(git branch --show-current) && gh-pages --add --message=\"Deploying to gh-pages from @ eBay/ebayui-core-react@$(git rev-parse --short HEAD) 🚀\" -d storybook-static",
     "test": "yarn jest",

--- a/src/common/floating-label-utils/hooks.tsx
+++ b/src/common/floating-label-utils/hooks.tsx
@@ -89,7 +89,6 @@ export function useFloatingLabel({
 
     const labelClassName = classNames('floating-label__label', {
         'floating-label__label--disabled': disabled,
-        'floating-label__label--inline': type !== 'date',
         'floating-label__label--invalid': invalid
     })
 

--- a/src/ebay-select/__tests__/render.spec.tsx
+++ b/src/ebay-select/__tests__/render.spec.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { composeStory } from '@storybook/react'
 import Meta, { Basic, InvalidSelect, BorderlessSelect, DisabledSelect, LargeSelect, FloatingLabel, InvalidFloatingLabelSelect, GroupedOptions } from './index.stories'
+import EbaySelect from '../ebay-select'
+import EbaySelectOption from '../ebay-select-option'
 
 const BasicStory = composeStory(Basic, Meta)
 const InvalidSelectStory = composeStory(InvalidSelect, Meta)
@@ -71,6 +73,32 @@ describe('ebay-select rendering', () => {
         const select = selectContainer.querySelector('select')
         const options = select.querySelectorAll('option')
         expect(options.length).toBe(4)
+    })
+
+    it('should not have "floating-label__label--inline" when there is a value', () => {
+        const { container } = render(
+            <EbaySelect value="1" floatingLabel="Label">
+                <EbaySelectOption value="">Choose</EbaySelectOption>
+                <EbaySelectOption value="1">1</EbaySelectOption>
+            </EbaySelect>
+        )
+
+        const label = container.querySelector('.floating-label__label')
+        expect(label).toHaveTextContent('Label')
+        expect(label).not.toHaveClass('floating-label__label--inline')
+    })
+
+    it('should have "floating-label__label--inline" when there is no value', () => {
+        const { container } = render(
+            <EbaySelect floatingLabel="Label">
+                <EbaySelectOption value="">Choose</EbaySelectOption>
+                <EbaySelectOption value="1">1</EbaySelectOption>
+            </EbaySelect>
+        )
+
+        const label = container.querySelector('.floating-label__label')
+        expect(label).toHaveTextContent('Label')
+        expect(label).toHaveClass('floating-label__label--inline')
     })
 
     it('renders invalid floating label select story correctly', () => {


### PR DESCRIPTION
# Description

- Remove `floating-label__label--inline` from our side as it is handle by makeup-floating-label