### PR TITLE
feat: Add new EbayFakeLink component

### DIFF
--- a/.changeset/giant-crabs-prove.md
+++ b/.changeset/giant-crabs-prove.md
@@ -1,0 +1,5 @@
+---
+"@ebay/ui-core-react": minor
+---
+
+feat: Add new EbayFakeLink component

--- a/src/ebay-fake-link/README.md
+++ b/src/ebay-fake-link/README.md
@@ -1,0 +1,44 @@
+# EbayFakeLink
+
+## Demo
+
+[Storybook](https://opensource.ebay.com/ebayui-core-react/main/?path=/docs/buttons-ebay-fake-link--docs)
+
+## Usage
+
+### Import JS
+
+```jsx harmony
+import { EbayFakeLink } from "@ebay/ui-core-react/ebay-fake-link";
+```
+
+### Import following styles from SKIN
+
+```jsx harmony
+import "@ebay/skin/link";
+```
+
+### If tokens haven't been added to the project at a higher level, make sure to import
+
+```jsx harmony
+import "@ebay/skin/tokens";
+```
+
+### Or import styles using SCSS/CSS
+
+```jsx harmony
+import "@ebay/skin/link.css";
+```
+
+```jsx harmony
+<EbayFakeLink>Fake Link</EbayFakeLink>
+```
+
+## Attributes
+
+It supports all `<button>` attributes and the below:
+
+| Name       | Type     | Required | Description                                                                                                                 | Data             |
+| ---------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `variant`  | String   | No       | Should only be standalone when it is clear contextually that this is a link, regardless of styles, `inline` or `standalone` |                  |
+| `onEscape` | Function | No       | Triggered on escape key                                                                                                     | `(event: Event)` |

--- a/src/ebay-fake-link/__tests__/__snapshots__/render.spec.tsx.snap
+++ b/src/ebay-fake-link/__tests__/__snapshots__/render.spec.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<EbayFakeLink /> rendering renders default story correctly 1`] = `
+<div>
+  <button
+    class="fake-link"
+    type="button"
+  >
+    Fake-Link
+  </button>
+</div>
+`;
+
+exports[`<EbayFakeLink /> rendering renders disabled button correctly 1`] = `
+<div>
+  <button
+    class="fake-link"
+    disabled=""
+    type="button"
+  >
+    Fake-Link
+  </button>
+</div>
+`;

--- a/src/ebay-fake-link/__tests__/index.spec.tsx
+++ b/src/ebay-fake-link/__tests__/index.spec.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import EbayFakeLink from '../fake-link';
+
+describe('<EbayFakeLink>', () => {
+    let component
+    let onClick = jest.fn()
+    let onEscape = jest.fn()
+
+    afterEach(jest.clearAllMocks)
+
+    describe("given button is enabled", () => {
+        beforeEach(async () => {
+            component = await render(
+                <EbayFakeLink onClick={onClick} onEscape={onEscape}>
+                    Fake-Link
+                </EbayFakeLink>
+            );
+        });
+
+        describe("when button is clicked", () => {
+            beforeEach(async () => {
+                await userEvent.click(component.getByRole("button"));
+            });
+
+            it("should emit the event with correct data", () => {
+                expect(onClick).toHaveBeenCalledTimes(1)
+            });
+        });
+
+        describe("when escape key is pressed", () => {
+            beforeEach(async () => {
+                component.getByRole("button").focus()
+                await userEvent.keyboard('{escape}');
+            });
+
+            it("should emit the event with correct data", () => {
+                expect(onEscape).toHaveBeenCalledTimes(1)
+            });
+        });
+    });
+
+    describe("given button is disabled", () => {
+        beforeEach(async () => {
+            component = await render(
+                <EbayFakeLink onClick={onClick} onEscape={onEscape} disabled>
+                    Fake-Link
+                </EbayFakeLink>
+            );
+        });
+
+        describe("when button is clicked", () => {
+            beforeEach(async () => {
+                await userEvent.click(component.getByRole("button"));
+            });
+
+            it("should not emit the event", () => {
+                expect(onClick).not.toHaveBeenCalled();
+            });
+        });
+
+        describe("when escape key is pressed", () => {
+            beforeEach(async () => {
+                component.getByRole("button").focus()
+                await userEvent.keyboard('{escape}');
+            });
+
+            it("should not emit the event", () => {
+                expect(onEscape).not.toHaveBeenCalled();
+            });
+        });
+    });
+})

--- a/src/ebay-fake-link/__tests__/index.stories.tsx
+++ b/src/ebay-fake-link/__tests__/index.stories.tsx
@@ -1,0 +1,80 @@
+
+import React from 'react'
+import { Meta, StoryFn } from '@storybook/react';
+import { EbayFakeLink } from '../index';
+
+const meta: Meta<typeof EbayFakeLink> = {
+    component: EbayFakeLink,
+    title: 'buttons/ebay-fake-link',
+    argTypes: {
+        disabled: {
+            description: "",
+            control: { type: 'boolean' },
+            table: {
+                category: "Toggles",
+                defaultValue: {
+                    summary: "false",
+                },
+            },
+        },
+        variant: {
+            description:
+                "Should only be standalone when it is clear contextually that this is a link, regardless of styles",
+            options: ["inline", "standalone"],
+            control: { type: "select" },
+            table: {
+                defaultValue: {
+                    summary: "inline",
+                },
+            },
+        },
+        onClick: {
+            action: "on-click",
+            description: "Triggered on click",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "event",
+                },
+            },
+        },
+        onEscape: {
+            action: "on-escape",
+            description: "Triggered on escape key",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "event",
+                },
+            },
+        },
+        onFocus: {
+            action: "on-focus",
+            description: "Triggered on focus",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "event",
+                },
+            },
+        },
+        onBlur: {
+            action: "on-blur",
+            description: "Triggered on blur",
+            table: {
+                category: "Events",
+                defaultValue: {
+                    summary: "event",
+                },
+            },
+        },
+    },
+}
+
+export default meta
+
+export const Default: StoryFn<typeof EbayFakeLink> = (args) => (
+    <EbayFakeLink {...args}>
+        Fake-Link
+    </EbayFakeLink>
+)

--- a/src/ebay-fake-link/__tests__/render.spec.tsx
+++ b/src/ebay-fake-link/__tests__/render.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { composeStories } from '@storybook/react'
+
+import * as stories from './index.stories'
+import { render } from '@testing-library/react'
+
+const { Default } = composeStories(stories)
+
+describe('<EbayFakeLink /> rendering', () => {
+    it('renders default story correctly', () => {
+        const { container } = render(<Default />)
+        expect(container).toMatchSnapshot()
+    })
+
+    it('renders disabled button correctly', () => {
+        const { container } = render(<Default disabled />)
+        expect(container).toMatchSnapshot()
+    })
+})

--- a/src/ebay-fake-link/fake-link.tsx
+++ b/src/ebay-fake-link/fake-link.tsx
@@ -1,0 +1,35 @@
+import React, { ComponentProps, FC } from 'react'
+import { EbayKeyboardEventHandler } from '../events'
+import classNames from 'classnames'
+
+export type EbayFakeLinkProps = ComponentProps<'button'> & {
+    variant?: 'inline' | 'standalone'
+    onEscape?: EbayKeyboardEventHandler<HTMLButtonElement>
+}
+
+const EbayFakeLink: FC<EbayFakeLinkProps> = ({
+    variant,
+    type,
+    className,
+    onKeyDown,
+    onEscape,
+    ...rest
+}) => {
+    const handleKeyDown: EbayKeyboardEventHandler<HTMLButtonElement> = (event) => {
+        onKeyDown?.(event)
+        if (event.key === 'Escape' || event.key === 'Esc') {
+            onEscape?.(event)
+        }
+    }
+
+    return (
+        <button
+            {...rest}
+            className={classNames('fake-link', variant === 'standalone' && 'standalone-link', className)}
+            onKeyDown={handleKeyDown}
+            type={type || 'button'}
+        />
+    )
+}
+
+export default EbayFakeLink

--- a/src/ebay-fake-link/index.ts
+++ b/src/ebay-fake-link/index.ts
@@ -1,0 +1,1 @@
+export { default as EbayFakeLink, type EbayFakeLinkProps } from './fake-link'


### PR DESCRIPTION
Marko: https://github.com/eBay/ebayui-core/tree/master/src/components/ebay-fake-link

Storybook: https://opensource.ebay.com/ebayui-core-react/fake-link/?path=/docs/buttons-ebay-fake-link--docs

Note: `standalone` variant currently don't have any behavior change, it should be fixed on skin

Fixes #274 